### PR TITLE
refactor(engine): create new action step type with skills and methods

### DIFF
--- a/packages/core/src/types/engine.types.ts
+++ b/packages/core/src/types/engine.types.ts
@@ -1,48 +1,5 @@
 import { z } from "zod";
 
-export const OnSchema = z.object({
-  success: z.string().optional(),
-  failure: z.string().optional(),
-});
-
-export const StepArgsSchema = z.record(z.string(), z.unknown());
-export type StepArgs = z.infer<typeof StepArgsSchema>;
-
-export const BaseStepSchema = z.object({
-  args: StepArgsSchema.optional(),
-  on: OnSchema.optional(),
-});
-
-export const ToolStepSchema = BaseStepSchema.extend({
-  type: z.enum(["tool"]),
-  mcp: z.string().min(1),
-  tool: z.string().min(1),
-});
-
-export const HttpStepSchema = BaseStepSchema.extend({
-  type: z.enum(["http"]),
-  url: z.string().url(),
-});
-
-export const StepSchema = z.discriminatedUnion("type", [
-  ToolStepSchema,
-  HttpStepSchema,
-]);
-
-export type Step = z.infer<typeof StepSchema>;
-export type ToolStep = z.infer<typeof ToolStepSchema>;
-export type HttpStep = z.infer<typeof HttpStepSchema>;
-
-export const FlowSchema = z.object({
-  name: z.string().min(1),
-  inputs: z.record(z.string(), z.unknown()).default({}),
-  outputs: z.record(z.string(), z.unknown()).default({}),
-  start: z.string().min(1),
-  steps: z.record(z.string(), StepSchema),
-});
-
-export type Flow = z.infer<typeof FlowSchema>;
-
 export const StatusSchema = z.enum([
   "running",
   "waiting",
@@ -79,7 +36,7 @@ export const RunContextSchema = z.object({
       attempt: z.number(),
       exports: z.record(z.string(), z.unknown()),
       result: z.record(z.string(), z.unknown()),
-      // TODO: implement history, an array of attemps and outputs
+      // TODO: implement history, an array of attempts and outputs
     })
   ),
 });

--- a/packages/core/src/types/flow.types.ts
+++ b/packages/core/src/types/flow.types.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+export const OnSchema = z.object({
+  success: z.string().optional(),
+  failure: z.string().optional(),
+});
+
+export const StepArgsSchema = z.record(z.string(), z.unknown());
+export type StepArgs = z.infer<typeof StepArgsSchema>;
+
+export const BaseStepSchema = z.object({
+  args: StepArgsSchema.optional(),
+  on: OnSchema.optional(),
+});
+
+export const ToolStepSchema = BaseStepSchema.extend({
+  type: z.enum(["tool"]),
+  mcp: z.string().min(1),
+  tool: z.string().min(1),
+});
+
+export const ActionStepSchema = BaseStepSchema.extend({
+  type: z.enum(["action"]),
+  skill: z.string().min(1),
+  method: z.string().min(1),
+});
+
+export const HttpStepSchema = BaseStepSchema.extend({
+  type: z.enum(["http"]),
+  url: z.string().url(),
+});
+
+export const StepSchema = z.discriminatedUnion("type", [
+  ToolStepSchema,
+  HttpStepSchema,
+]);
+
+export type Step = z.infer<typeof StepSchema>;
+export type ToolStep = z.infer<typeof ToolStepSchema>;
+export type HttpStep = z.infer<typeof HttpStepSchema>;
+
+export const FlowSchema = z.object({
+  name: z.string().min(1),
+  inputs: z.record(z.string(), z.unknown()).default({}),
+  outputs: z.record(z.string(), z.unknown()).default({}),
+  start: z.string().min(1),
+  steps: z.record(z.string(), StepSchema),
+});
+
+export type Flow = z.infer<typeof FlowSchema>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./event-bus.types.js";
 export * from "./engine.types.js";
+export * from "./flow.types.js";


### PR DESCRIPTION
## Summary

Refactoring the design of step actions to be generic invocations by the engine, and route logic through skills, methods, services, and profiles.

## Related Issues

Closes #28 

## Changes

- Move flow definition types out of engine and into its own file.
- Add `action` step type definition.

## Notes

- Currently all types are done in zod, with typescript inferred.  Once final shapes are in place, the spec may be defined in JSON schema and validated with ajv.   Possibly still export Typescript only definitions or zod, depending on what validation system works out.