### PR TITLE
feat(core): add step executor types and port interface

### DIFF
--- a/packages/core/src/ports/level-invoker.port.ts
+++ b/packages/core/src/ports/level-invoker.port.ts
@@ -1,0 +1,5 @@
+// simple Level invoke interface
+// skeleton to help shape StepExecutor
+export interface LevelInvokerPort {
+  invoke(world: string, level: string, args: unknown): Promise<unknown>;
+}

--- a/packages/core/src/ports/ports.ts
+++ b/packages/core/src/ports/ports.ts
@@ -1,0 +1,7 @@
+import { LevelInvokerPort } from "./level-invoker.port.js";
+
+// general package shape of ports for dependency injection
+// unsure what this should be named long term
+export interface Ports {
+  invoker: LevelInvokerPort;
+}

--- a/packages/core/src/types/step-executor.type.ts
+++ b/packages/core/src/types/step-executor.type.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import type { Step } from "./flow.types.js";
+import { RunContext } from "./engine.types.js";
+import { Ports } from "../ports/ports.js";
+
+export const StepResultSchema = z.object({
+  ok: z.boolean(),
+  result: z.record(z.string(), z.unknown()),
+  exports: z.record(z.string(), z.unknown()).optional(),
+  next: z.string().optional(),
+  error: z
+    .object({
+      message: z.string(),
+      code: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type StepResult = z.infer<typeof StepResultSchema>;
+
+export type StepExecutor = (args: {
+  ctx: RunContext;
+  step: Step;
+  ports: Ports;
+}) => Promise<StepResult>;


### PR DESCRIPTION
## Summary

Create the basic types for a `StepExecutor` function type with supporting types.  Add a Port interface to wrap port dependencies together.

## Checklist

- Add very basic level-invoker port
- Add Port interface
- Add StepExecutor type and return type