### PR TITLE
chore: add specs and ports package

### DIFF
--- a/packages/ports/package.json
+++ b/packages/ports/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pipewarp/ports",
+  "version": "0.1.0-alpha.0",
+  "private": "true",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --incremental false",
+    "typecheck": "tsc --noEmit",
+    "test": "echo test",
+    "lint": "echo lint"
+  },
+  "packageManager": "pnpm@10.17.1",
+  "dependencies": {
+    "zod": "3.25.76"
+  }
+}

--- a/packages/ports/src/engine.port.ts
+++ b/packages/ports/src/engine.port.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+export const FlowNameSchema = z.string();
+export const FlowRunIdSchema = z.string();
+export const StepIdSchema = z.string();
+export const TaskIdSchema = z.string();
+export const ResourecKeySchema = z.string();
+
+export const StepOutcomeSchema = z.union([
+  z.literal("success"),
+  z.literal("failure"),
+]);
+
+export const StartFlowInputSchema = z.object({
+  flowName: FlowNameSchema,
+  inputs: z.unknown(),
+  correlationId: z.string(),
+  test: z.boolean().default(false).optional(),
+  outfile: z.string().default("runs/").optional(),
+});
+
+export type StartFlowInput = z.infer<typeof StartFlowInputSchema>;
+
+export const StartFlowResultSchema = z.object({
+  flowRunId: FlowRunIdSchema,
+  flowName: FlowNameSchema,
+  startStepId: StepIdSchema,
+  startedAt: z.string(), // iso date string
+});
+
+export type StartFlowResult = z.infer<typeof StartFlowInputSchema>;
+
+export const ExecuteStepCommandSchema = z.object({
+  stepName: StepIdSchema,
+  runId: FlowNameSchema,
+  taskId: TaskIdSchema,
+  attempt: z.number(),
+  mcpId: ResourecKeySchema,
+  args: z.unknown().optional(),
+  timeoutMs: z.number().optional(),
+});
+
+export type ExecuteStepCommand = z.infer<typeof ExecuteStepCommandSchema>;
+
+export const ExecuteStepResultSchema = z.object({
+  outcome: StepOutcomeSchema,
+  retriable: z.boolean().optional(),
+  resultSummary: z.unknown().optional(),
+  errorSummary: z.unknown().optional(),
+  next: z.object({
+    stepId: StepIdSchema,
+  }),
+});
+
+export interface EnginePort {
+  startFlow(input: StartFlowInput): Promise<StartFlowResult | undefined>;
+  executeStep(cmd: ExecuteStepCommand): Promise<ExecuteStepCommand | undefined>;
+}

--- a/packages/ports/src/event-bus.port.ts
+++ b/packages/ports/src/event-bus.port.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+// messages have payloads with events
+// message types tell what type of message is being sent
+// each message type has an event payload
+
+export const StepEventSchema = z.object({
+  stepName: z.string().min(1),
+  runId: z.string().min(1),
+  flowName: z.string().min(1),
+  mcpId: z.string().min(1),
+  args: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type StepEvent = z.infer<typeof StepEventSchema>;
+
+export const EventEnvelopeSchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  time: z.string().min(1),
+  data: StepEventSchema,
+});
+
+export type EventEnvelope = z.infer<typeof EventEnvelopeSchema>;
+
+// could have CommandEnvelop, QueryEnvelope to define different message types
+// unsure the schema changes.  One Message type which multiple envelopes?
+// each envelope has similar message metadata, otel, observability?
+
+export interface EventBusPort {
+  publish(topic: string, event: EventEnvelope): Promise<void>;
+  subscribe(topic: string, handler: () => Promise<void>): () => unknown;
+  close(): Promise<unknown>;
+}

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./engine.port.js";
+export * from "./event-bus.port.js";
+export * from "./mcp-runner.port.js";
+export * from "./level-invoker.port.js";

--- a/packages/ports/src/level-invoker.port.ts
+++ b/packages/ports/src/level-invoker.port.ts
@@ -1,0 +1,5 @@
+// simple Level invoke interface
+// skeleton to help shape StepExecutor
+export interface LevelInvokerPort {
+  invoke(world: string, level: string, args: unknown): Promise<unknown>;
+}

--- a/packages/ports/src/mcp-runner.port.ts
+++ b/packages/ports/src/mcp-runner.port.ts
@@ -1,0 +1,6 @@
+import { EventEnvelope } from "./event-bus.port.js";
+
+export interface McpRunnerPort {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/packages/ports/src/ports.ts
+++ b/packages/ports/src/ports.ts
@@ -1,0 +1,7 @@
+import { LevelInvokerPort } from "./level-invoker.port.js";
+
+// general package shape of ports for dependency injection
+// unsure what this should be named long term
+export interface Ports {
+  invoker: LevelInvokerPort;
+}

--- a/packages/ports/tsconfig.json
+++ b/packages/ports/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pipewarp/specs",
+  "version": "0.1.0-alpha.0",
+  "private": "true",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --incremental false",
+    "typecheck": "tsc --noEmit",
+    "test": "echo test",
+    "lint": "echo lint"
+  },
+  "packageManager": "pnpm@10.17.1",
+  "dependencies": {
+    "zod": "3.25.76"
+  }
+}

--- a/packages/specs/src/engine.types.ts
+++ b/packages/specs/src/engine.types.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const StatusSchema = z.enum([
+  "running",
+  "waiting",
+  "queued",
+  "idle",
+  "started",
+  "stopped",
+  "aborted",
+  "success",
+  "failure",
+  "error",
+]);
+
+export type Status = z.infer<typeof StatusSchema>;
+
+export const RunStepContextSchema = z.object({
+  status: StatusSchema,
+});
+
+export const RunContextSchema = z.object({
+  runId: z.string().min(1),
+  flowName: z.string().min(1),
+  test: z.boolean().default(false).optional(),
+  outFile: z.string().default("./output.json").optional(),
+  inputs: z.record(z.string(), z.unknown()),
+  exports: z.record(z.string(), z.unknown()),
+  globals: z.record(z.string(), z.unknown()),
+  status: StatusSchema,
+  steps: z.record(
+    z.string(),
+    z.object({
+      status: StatusSchema,
+      reason: z.string().optional(),
+      attempt: z.number(),
+      exports: z.record(z.string(), z.unknown()),
+      result: z.record(z.string(), z.unknown()),
+      // TODO: implement history, an array of attempts and outputs
+    })
+  ),
+});
+
+export type RunContext = z.infer<typeof RunContextSchema>;

--- a/packages/specs/src/flow.types.ts
+++ b/packages/specs/src/flow.types.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+export const OnSchema = z.object({
+  success: z.string().optional(),
+  failure: z.string().optional(),
+});
+
+export const StepArgsSchema = z.record(z.string(), z.unknown());
+export type StepArgs = z.infer<typeof StepArgsSchema>;
+
+export const BaseStepSchema = z.object({
+  args: StepArgsSchema.optional(),
+  on: OnSchema.optional(),
+});
+
+// TODO: Old step format; to be removed
+export const ToolStepSchema = BaseStepSchema.extend({
+  type: z.enum(["tool"]),
+  mcp: z.string().min(1),
+  tool: z.string().min(1),
+});
+
+export const WarpStepSchema = BaseStepSchema.extend({
+  type: z.enum(["warp"]),
+  world: z.string().min(1),
+  level: z.string().min(1),
+  play: z
+    .object({
+      path: z.string().min(1).optional(),
+      portal: z.string().min(1).optional(),
+    })
+    .optional(),
+});
+
+export const HttpStepSchema = BaseStepSchema.extend({
+  type: z.enum(["http"]),
+  url: z.string().url(),
+});
+
+export const StepSchema = z.discriminatedUnion("type", [
+  ToolStepSchema,
+  HttpStepSchema,
+  WarpStepSchema,
+]);
+
+export type Step = z.infer<typeof StepSchema>;
+export type ToolStep = z.infer<typeof ToolStepSchema>;
+export type HttpStep = z.infer<typeof HttpStepSchema>;
+export type WarpStep = z.infer<typeof WarpStepSchema>;
+
+export const FlowSchema = z.object({
+  name: z.string().min(1),
+  inputs: z.record(z.string(), z.unknown()).default({}),
+  outputs: z.record(z.string(), z.unknown()).default({}),
+  start: z.string().min(1),
+  steps: z.record(z.string(), StepSchema),
+});
+
+export type Flow = z.infer<typeof FlowSchema>;

--- a/packages/specs/src/index.ts
+++ b/packages/specs/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./engine.types.js";
+export * from "./flow.types.js";

--- a/packages/specs/src/result.types.ts
+++ b/packages/specs/src/result.types.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const TestResultSchema = z.object({
+  runId: z.string(),
+  flow: z.object({
+    name: z.string(),
+    path: z.string(),
+  }),
+  status: z.enum(["ok", "error"]),
+});

--- a/packages/specs/src/step-executor.type.ts
+++ b/packages/specs/src/step-executor.type.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import type { Step } from "./flow.types.js";
+import { RunContext } from "./engine.types.js";
+// import { Ports } from "../ports/ports.js";
+
+type Ports = {};
+
+export const StepResultSchema = z.object({
+  ok: z.boolean(),
+  result: z.record(z.string(), z.unknown()),
+  exports: z.record(z.string(), z.unknown()).optional(),
+  next: z.string().optional(),
+  error: z
+    .object({
+      message: z.string(),
+      code: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type StepResult = z.infer<typeof StepResultSchema>;
+
+export type StepExecutor = (args: {
+  ctx: RunContext;
+  step: Step;
+  ports: Ports;
+}) => Promise<StepResult>;

--- a/packages/specs/tsconfig.json
+++ b/packages/specs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,18 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/ports:
+    dependencies:
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/specs:
+    dependencies:
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
 packages:
 
   '@esbuild/aix-ppc64@0.25.10':


### PR DESCRIPTION
## Summary

Split out core into `specs` and `ports`.

Executor will split out into an adapter.

This is part of a reorganization of packages to support refactoring the engine and future growth.