### PR TITLE
chore: move executors to adapters and ports

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -26,6 +26,8 @@
   "packageManager": "pnpm@10.17.1",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.19.1",
-    "@pipewarp/core": "workspace:*"
+    "@pipewarp/core": "workspace:*",
+    "@pipewarp/ports": "workspace:*",
+    "@pipewarp/specs": "workspace:*"
   }
 }

--- a/packages/adapters/src/executors/action.executor.ts
+++ b/packages/adapters/src/executors/action.executor.ts
@@ -1,0 +1,28 @@
+import { Ports } from "@pipewarp/ports";
+import { Step, WarpStepSchema } from "@pipewarp/specs";
+import type { StepExecutor, StepResult } from "@pipewarp/ports";
+
+export const actionExecutor: StepExecutor =
+  async (args: {}): Promise<StepResult> => {
+    // const { ports, step } = args;
+
+    // const result = WarpStepSchema.safeParse(step);
+    // if (!result.success) {
+    //   console.error("[warp executor] invalid warp step:", result.error);
+    //   return {
+    //     ok: false,
+    //     result: {},
+    //     error: { message: "Invalid warp step" },
+    //   };
+    // }
+
+    // const warpStep = result.data;
+
+    // const out = await ports.invoker.invoke(
+    //   warpStep.world,
+    //   warpStep.level,
+    //   warpStep.args
+    // );
+
+    return { ok: true, result: {} };
+  };

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -2,3 +2,5 @@ export * from "./engine.port.js";
 export * from "./event-bus.port.js";
 export * from "./mcp-runner.port.js";
 export * from "./level-invoker.port.js";
+export * from "./ports.js";
+export * from "./step-executor.type.js";

--- a/packages/ports/src/step-executor.type.ts
+++ b/packages/ports/src/step-executor.type.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+type InvokeRequest = {};
+type InvokeContext = {};
+
+export const StepResultSchema = z.object({
+  ok: z.boolean(),
+  result: z.record(z.string(), z.unknown()),
+  exports: z.record(z.string(), z.unknown()).optional(),
+  next: z.string().optional(),
+  error: z
+    .object({
+      message: z.string(),
+      code: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type StepResult = z.infer<typeof StepResultSchema>;
+
+export type StepExecutor = (args: {
+  ctx: InvokeContext;
+  invokeRequest: InvokeRequest;
+}) => Promise<StepResult>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,12 @@ importers:
       '@pipewarp/core':
         specifier: workspace:*
         version: link:../core
+      '@pipewarp/ports':
+        specifier: workspace:*
+        version: link:../ports
+      '@pipewarp/specs':
+        specifier: workspace:*
+        version: link:../specs
 
   packages/core:
     dependencies:


### PR DESCRIPTION
## Summary

Moving executors out of core and giving its own port.  Executors will be broken as they are rewritten with definitions from specs and ports unique to the limited types and dependencies they actually need.