### PR TITLE
feat(bus): add pattern matching to inmemory event bus

### DIFF
--- a/packages/adapters/src/event-bus/inmemory.event-bus.ts
+++ b/packages/adapters/src/event-bus/inmemory.event-bus.ts
@@ -29,15 +29,13 @@ export class InMemoryEventBus implements EventBusPort {
     event: AnyEvent,
     options?: PublishOptions
   ): Promise<void> {
-    let topics = this.getTopics(topic, options);
+    const topics = this.getTopics(topic, options);
 
     const payload = Object.freeze(event);
 
     queueMicrotask(() => {
       try {
-        for (const topic of topics) {
-          this.#ee.emit(topic, payload);
-        }
+        for (const topic of topics) this.#ee.emit(topic, payload);
       } catch (err) {
         console.error(`[bus.publish]: emit error '${topic}', event:${payload}`);
         console.error(err);
@@ -77,7 +75,7 @@ export class InMemoryEventBus implements EventBusPort {
     }
 
     topics.push(this.wildcard); // otherwise add wildcard
-    topics.push(topic); // add the raw topic... next get permutations
+    topics.push(topic); // add the raw topic... next get patterns
 
     if (this.#patterns.has(topic)) {
       const patterns = this.#patterns.get(topic);

--- a/packages/adapters/tests/event-bus/inmemory-bus.test.ts
+++ b/packages/adapters/tests/event-bus/inmemory-bus.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { InMemoryEventBus } from "../../src/event-bus/inmemory.event-bus.js";
 
 describe("[inmemory-event-bus]", () => {
+  it("generates no patterns for a one element topic ", () => {
+    const bus = new InMemoryEventBus();
+
+    const patterns = bus.generatePatterns("job");
+    expect(patterns).toBeDefined();
+    expect(patterns?.length).toEqual(0);
+  });
   it("generates two patterns for a valid two element topic ", () => {
     const bus = new InMemoryEventBus();
 

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -2,10 +2,9 @@ import fs from "fs";
 import type { RunContext, Flow } from "@lcase/specs";
 import type { EventBusPort, StreamRegistryPort } from "@lcase/ports";
 import type { AnyEvent } from "@lcase/types";
-import { EmitterFactory } from "@lcase/events";
+import { EmitterFactory, eventParser } from "@lcase/events";
 import { FlowStore } from "@lcase/adapters/flow-store";
 import type { StepHandlerRegistry } from "./step-handler.registry.js";
-import { threadId } from "worker_threads";
 import { CapId } from "@lcase/types/flow";
 
 /**
@@ -28,7 +27,7 @@ export class Engine {
   ) {}
 
   async subscribeToTopics(): Promise<void> {
-    this.bus.subscribe("flows.lifecycle", async (e: AnyEvent) => {
+    this.bus.subscribe("flow.queued", async (e: AnyEvent) => {
       if (e.type === "flow.queued") {
         const event = e as AnyEvent<"flow.queued">;
 
@@ -57,14 +56,12 @@ export class Engine {
       }
     });
 
-    this.bus.subscribe("jobs.lifecycle", async (e: AnyEvent) => {
+    this.bus.subscribe("job.completed", async (e: AnyEvent) => {
       if (e.type === "job.completed") {
         const jobCompletedEvent = e as AnyEvent<"job.completed">;
         await this.handleWorkerDone(jobCompletedEvent);
       }
     });
-
-    this.bus.subscribe("workers.lifecycle", async (e: AnyEvent) => {});
   }
 
   async start() {

--- a/packages/events/src/emitters/engine.emitter.ts
+++ b/packages/events/src/emitters/engine.emitter.ts
@@ -62,6 +62,6 @@ export class EngineEmitter extends BaseEmitter {
         `[flow-emitter] error parsing event; ${type}; ${result.error}`
       );
     }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
   }
 }

--- a/packages/events/src/emitters/flow.emitter.ts
+++ b/packages/events/src/emitters/flow.emitter.ts
@@ -62,6 +62,6 @@ export class FlowEmitter extends BaseEmitter {
         `[flow-emitter] error parsing event; ${type}; ${result.error}`
       );
     }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
   }
 }

--- a/packages/events/src/emitters/jobs.emitter.ts
+++ b/packages/events/src/emitters/jobs.emitter.ts
@@ -62,7 +62,7 @@ export class JobEmitter extends BaseEmitter {
         `[flow-emitter] error parsing event; ${type}; ${result.error}`
       );
     }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
     return event;
   }
 }

--- a/packages/events/src/emitters/run.emitter.ts
+++ b/packages/events/src/emitters/run.emitter.ts
@@ -62,6 +62,6 @@ export class RunEmitter extends BaseEmitter {
         `[flow-emitter] error parsing event; ${type}; ${result.error}`
       );
     }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
   }
 }

--- a/packages/events/src/emitters/step.emitter.ts
+++ b/packages/events/src/emitters/step.emitter.ts
@@ -61,6 +61,6 @@ export class StepEmitter extends BaseEmitter {
     //     `[step-emitter] error parsing event; ${type}; ${result.error}`
     //   );
     // }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
   }
 }

--- a/packages/events/src/emitters/system.emitter.ts
+++ b/packages/events/src/emitters/system.emitter.ts
@@ -62,6 +62,6 @@ export class SystemEmitter extends BaseEmitter implements SystemEmitterPort {
         `[flow-emitter] error parsing event; ${type}; ${result.error}`
       );
     }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
   }
 }

--- a/packages/events/src/emitters/tool.emitter.ts
+++ b/packages/events/src/emitters/tool.emitter.ts
@@ -62,6 +62,6 @@ export class ToolEmitter extends BaseEmitter {
         `[flow-emitter] error parsing event; ${type}; ${result.error}`
       );
     }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
   }
 }

--- a/packages/events/src/emitters/worker.emitter.ts
+++ b/packages/events/src/emitters/worker.emitter.ts
@@ -61,6 +61,6 @@ export class WorkerEmitter extends BaseEmitter {
         `[worker-emitter] error parsing event; ${type}; ${result.error}`
       );
     }
-    await this.bus.publish(entry.topic, event);
+    await this.bus.publish(type, event);
   }
 }

--- a/packages/resource-manager/src/resource-manager.ts
+++ b/packages/resource-manager/src/resource-manager.ts
@@ -48,11 +48,7 @@ export class ResourceManager implements ResourceManagerPort {
       async (event) => await this.handleRequest(event)
     );
     this.#bus.subscribe(
-      "job.httpjson.submitted",
-      async (event) => await this.handleRequest(event)
-    );
-    this.#bus.subscribe(
-      "job.mcp.submitted",
+      "job.*.submitted",
       async (event) => await this.handleRequest(event)
     );
   }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -77,7 +77,7 @@ export class Worker {
   }
 
   #subscribeToBus(): void {
-    this.#bus.subscribe("workers.lifecycle", async (e: AnyEvent) => {
+    this.#bus.subscribe("worker.registered", async (e: AnyEvent) => {
       if (e.type === "worker.registered") {
         const event = e as AnyEvent<"worker.registered">;
         if (


### PR DESCRIPTION
## Summary

This PR adds simple pattern matching to the in memory version of the event bus.  Topics are expected to be in two or three words separated by `.` characters.   The event bus just emits all five or eight combinations of topics.  

For example `job.submitted` gets emitted to `observability`, `*`, `job.*`, `*.submitted`, `job.submitted`, regardless of active listeners.

Three part event types ( `job.mcp.submitted`) are emit the same pattern of prefixes and suffixes, along with a middle `job.*.submitted` wildcard event topic.

This push helps make topic broadcasting easier to understand and standard across the codebase, in prep for better routing in the Resource Manger and elsewhere.

## Changes

- [x] Add pattern matching to in memory event bus version.
- [x] Update code throughout to publish events to literal event names.  Have listeners listen to appropriate topic patterns.