### PR TITLE
feat(types): add `ForkSpec` types + events

### DIFF
--- a/packages/engine/src/engine.types.ts
+++ b/packages/engine/src/engine.types.ts
@@ -25,7 +25,7 @@ import type {
   StepScope,
   StepStartedData,
 } from "@lcase/types";
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type {
   StepFinishedMsg,
   StepPlannedMsg,
@@ -245,7 +245,7 @@ export type EngineEffect =
 // reducers
 export type Reducer<M extends EngineMessage = EngineMessage> = (
   state: EngineState,
-  message: M
+  message: M,
 ) => EngineState;
 
 export type ReducerRegistry = {
@@ -256,7 +256,7 @@ export type ReducerRegistry = {
 export type Planner<M extends EngineMessage = EngineMessage> = (
   oldState: EngineState,
   newState: EngineState,
-  message: M
+  message: M,
 ) => EngineEffect[];
 
 export type PlannerRegistry = {
@@ -266,11 +266,11 @@ export type PlannerRegistry = {
 // handlers
 export type EffectHandler<T extends EngineEffect["type"]> = (
   effect: Extract<EngineEffect, { type: T }>,
-  deps: EffectHandlerDeps
+  deps: EffectHandlerDeps,
 ) => void | Promise<void>;
 
 export type EffectHandlerWrapped<T extends EngineEffect["type"]> = (
-  effect: Extract<EngineEffect, { type: T }>
+  effect: Extract<EngineEffect, { type: T }>,
 ) => void | Promise<void>;
 
 export type EffectHandlerRegistry = {

--- a/packages/engine/src/pipe-resolver.ts
+++ b/packages/engine/src/pipe-resolver.ts
@@ -1,5 +1,5 @@
 // import type { StreamRegistryPort } from "@lcase/ports";
-// import { RunContext } from "@lcase/types/engine";
+// import { RunContext } from "@lcase/types";
 // import { randomUUID } from "crypto";
 
 // export type ResolvedPipes = {

--- a/packages/engine/src/reducers/flow-submitted.reducer.ts
+++ b/packages/engine/src/reducers/flow-submitted.reducer.ts
@@ -1,5 +1,5 @@
 import { produce } from "immer";
-import { RunContext, StepContext } from "@lcase/types/engine";
+import { RunContext, StepContext } from "@lcase/types";
 import { EngineState, FlowSubmittedMsg, Reducer } from "../engine.types.js";
 import { StepDefinition } from "@lcase/types";
 import { analyzeFlow, analyzeRefs } from "@lcase/flow-analysis";
@@ -14,7 +14,7 @@ import { analyzeFlow, analyzeRefs } from "@lcase/flow-analysis";
  */
 export const flowSubmittedReducer: Reducer<FlowSubmittedMsg> = (
   state: EngineState,
-  message: FlowSubmittedMsg
+  message: FlowSubmittedMsg,
 ): EngineState => {
   return produce(state, (draft) => {
     // make step context for all steps
@@ -76,7 +76,7 @@ export const flowSubmittedReducer: Reducer<FlowSubmittedMsg> = (
  * @param steps Record<string, StepDefinition>
  */
 export function makeJoinSetsForSteps(
-  steps: Record<string, StepDefinition>
+  steps: Record<string, StepDefinition>,
 ): Record<string, Record<string, boolean>> {
   const joinMap: Record<string, Record<string, boolean>> = {};
   for (const definition of Object.values(steps)) {

--- a/packages/engine/src/reducers/utils/complete-parallel-edge.reducer.ts
+++ b/packages/engine/src/reducers/utils/complete-parallel-edge.reducer.ts
@@ -1,10 +1,10 @@
 import type { Edge } from "@lcase/types";
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type { WritableDraft } from "immer";
 
 export function completeParallelEdge(
   edge: WritableDraft<Edge>,
-  run: WritableDraft<RunContext>
+  run: WritableDraft<RunContext>,
 ) {
   if (run.steps[edge.startStepId] === undefined) return;
   const parallelStepId = edge.startStepId;

--- a/packages/engine/src/reducers/utils/plan-control-edge.reducer.ts
+++ b/packages/engine/src/reducers/utils/plan-control-edge.reducer.ts
@@ -1,11 +1,11 @@
 import type { Edge } from "@lcase/types";
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type { WritableDraft } from "immer";
 
 export function planControlEdge(
   edge: WritableDraft<Edge>,
   run: WritableDraft<RunContext>,
-  gate: "onSuccess" | "onFailure"
+  gate: "onSuccess" | "onFailure",
 ) {
   if (run.steps[edge.endStepId] === undefined) return;
   if (

--- a/packages/engine/src/reducers/utils/plan-join-edge.reducer.ts
+++ b/packages/engine/src/reducers/utils/plan-join-edge.reducer.ts
@@ -1,11 +1,11 @@
 import { Edge } from "@lcase/types";
-import { RunContext } from "@lcase/types/engine";
+import { RunContext } from "@lcase/types";
 import { WritableDraft } from "immer";
 import { planControlEdge } from "./plan-control-edge.reducer.js";
 
 export function planJoinEdge(
   edge: WritableDraft<Edge>,
-  run: WritableDraft<RunContext>
+  run: WritableDraft<RunContext>,
 ) {
   if (edge.type !== "join") return;
   // if they all succeeded, succeed/complete join

--- a/packages/engine/src/reducers/utils/set-run-status.reducer.ts
+++ b/packages/engine/src/reducers/utils/set-run-status.reducer.ts
@@ -1,4 +1,4 @@
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type { WritableDraft } from "immer";
 
 export function setRunStatus(run: WritableDraft<RunContext>) {

--- a/packages/engine/src/references/value-refs.ts
+++ b/packages/engine/src/references/value-refs.ts
@@ -1,5 +1,5 @@
 import type { Ref } from "@lcase/types";
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 
 /**
  * Makes an array of value ref objects for a list of references.

--- a/packages/engine/src/resolve.ts
+++ b/packages/engine/src/resolve.ts
@@ -1,5 +1,5 @@
 import type { StepArgs } from "@lcase/specs";
-import type { RunContext, StepContext } from "@lcase/types/engine";
+import type { RunContext, StepContext } from "@lcase/types";
 
 /**
  * internally here language is currently evolving.
@@ -22,7 +22,7 @@ export function split(path: string): string[] {
 
 export function resolveFlatFields(
   fields: Record<string, string>,
-  object: Record<string, unknown>
+  object: Record<string, unknown>,
 ): Record<string, unknown> {
   const fieldValues: Record<string, unknown> = {};
   for (const [field, selector] of Object.entries(fields)) {
@@ -35,7 +35,7 @@ export function resolveFlatFields(
 }
 export function resolveSelector(
   selector: string,
-  object: Record<string, unknown>
+  object: Record<string, unknown>,
 ) {
   const parsedSelector = getSelector(selector);
   if (!parsedSelector) return;
@@ -52,7 +52,7 @@ export function resolvePath(path: string, object: Record<string, unknown>) {
 // dig through object to see if we can get a data type from context
 export function extractPathValue<T = unknown>(
   parts: Part[],
-  obj: Record<string, unknown>
+  obj: Record<string, unknown>,
 ): T | unknown {
   let current: unknown = obj;
 
@@ -86,7 +86,7 @@ export function parseArray(part: string): { key?: string; index?: string[] } {
 
 export function resolveStepArgs(
   stepContext: Record<string, StepContext>,
-  stepArgs: StepArgs
+  stepArgs: StepArgs,
 ): Record<string, unknown> {
   if (!stepArgs) return {};
   // one level deep not recursive

--- a/packages/engine/tests/fixtures/flow-submitted.state.ts
+++ b/packages/engine/tests/fixtures/flow-submitted.state.ts
@@ -1,4 +1,4 @@
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type {
   EngineState,
   FlowContext,

--- a/packages/engine/tests/fixtures/run-started.state.ts
+++ b/packages/engine/tests/fixtures/run-started.state.ts
@@ -1,4 +1,4 @@
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type {
   EngineState,
   FlowContext,

--- a/packages/engine/tests/fixtures/step-planned.state.ts
+++ b/packages/engine/tests/fixtures/step-planned.state.ts
@@ -1,4 +1,4 @@
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type {
   EngineState,
   FlowContext,

--- a/packages/engine/tests/fixtures/step-started.state.ts
+++ b/packages/engine/tests/fixtures/step-started.state.ts
@@ -1,4 +1,4 @@
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type {
   EngineState,
   FlowContext,

--- a/packages/engine/tests/planners/flow-submitted.planner.test.ts
+++ b/packages/engine/tests/planners/flow-submitted.planner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type {
   FlowSubmittedMsg,
   EngineState,

--- a/packages/engine/tests/reducers/flow-submitted.reducer.test.ts
+++ b/packages/engine/tests/reducers/flow-submitted.reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { RunContext } from "@lcase/types/engine";
+import type { RunContext } from "@lcase/types";
 import type {
   FlowSubmittedMsg,
   EngineState,

--- a/packages/events/src/otel-attributes.ts
+++ b/packages/events/src/otel-attributes.ts
@@ -79,6 +79,11 @@ export const engineOtelAttributesMap = {
 } satisfies EngineOtelAttributesMap;
 
 export const runOtelAttributesMap = {
+  "run.requested": {
+    action: "requested",
+    domain: "run",
+    entity: undefined,
+  },
   "run.completed": {
     action: "completed",
     domain: "run",

--- a/packages/events/src/registries/event-schema.registry.ts
+++ b/packages/events/src/registries/event-schema.registry.ts
@@ -27,11 +27,13 @@ import {
 import {
   RunCompletedSchema,
   RunFailedSchema,
+  RunRequestedSchema,
   RunStartedSchema,
 } from "../schemas/run.event.schema.js";
 import {
   RunCompletedDataSchema,
   RunFailedDataSchema,
+  RunRequestedDataSchema,
   RunStartedDataSchema,
 } from "../schemas/run.data.schema.js";
 import {
@@ -158,6 +160,12 @@ export const eventSchemaRegistry = {
     schema: {
       event: EngineStoppedSchema,
       data: EngineStoppedDataSchema,
+    },
+  },
+  "run.requested": {
+    schema: {
+      event: RunRequestedSchema,
+      data: RunRequestedDataSchema,
     },
   },
   "run.started": {

--- a/packages/events/src/registries/event-types.ts
+++ b/packages/events/src/registries/event-types.ts
@@ -25,6 +25,7 @@ export const eventTypes = [
   "flow.analyzed",
   "engine.started",
   "engine.stopped",
+  "run.requested",
   "run.completed",
   "run.started",
   "run.failed",

--- a/packages/events/src/schemas/run.data.schema.ts
+++ b/packages/events/src/schemas/run.data.schema.ts
@@ -3,6 +3,7 @@ import type {
   RunStartedData,
   RunCompletedData,
   RunFailedData,
+  RunRequestedData,
 } from "@lcase/types";
 
 // removed descriptor for now to reduce duplication of data
@@ -15,6 +16,13 @@ const RunDescriptorSchema = z.object({
     id: z.string(),
   }),
 });
+
+export const RunRequestedDataSchema = z
+  .object({
+    flowDefHash: z.string(),
+    forkSpecHash: z.string().optional(),
+  })
+  .strict() satisfies z.ZodType<RunRequestedData>;
 
 export const RunStartedDataSchema =
   z.null() satisfies z.ZodType<RunStartedData>;

--- a/packages/events/src/schemas/run.event.schema.ts
+++ b/packages/events/src/schemas/run.event.schema.ts
@@ -4,6 +4,7 @@ import { RunScope, AnyEvent } from "@lcase/types";
 import {
   RunCompletedDataSchema,
   RunFailedDataSchema,
+  RunRequestedDataSchema,
   RunStartedDataSchema,
 } from "./run.data.schema.js";
 
@@ -15,6 +16,17 @@ export const RunContextSchema = z
   })
   .strict() satisfies z.ZodType<RunScope>;
 
+export const RunRequestedSchema = z
+  .object({
+    ...CloudEventContextSchema.shape,
+    ...RunContextSchema.shape,
+    type: z.literal("run.requested"),
+    entity: z.undefined().optional(),
+    action: z.literal("requested"),
+    data: RunRequestedDataSchema,
+  })
+  .strict() satisfies z.ZodType<AnyEvent<"run.requested">>;
+
 export const RunStartedSchema = CloudEventContextSchema.merge(RunContextSchema)
   .merge(
     z.object({
@@ -22,12 +34,12 @@ export const RunStartedSchema = CloudEventContextSchema.merge(RunContextSchema)
       entity: z.undefined().optional(),
       action: z.literal("started"),
       data: RunStartedDataSchema,
-    })
+    }),
   )
   .strict() satisfies z.ZodType<AnyEvent<"run.started">>;
 
 export const RunCompletedSchema = CloudEventContextSchema.merge(
-  RunContextSchema
+  RunContextSchema,
 )
   .merge(
     z.object({
@@ -35,7 +47,7 @@ export const RunCompletedSchema = CloudEventContextSchema.merge(
       entity: z.undefined().optional(),
       action: z.literal("completed"),
       data: RunCompletedDataSchema,
-    })
+    }),
   )
   .strict() satisfies z.ZodType<AnyEvent<"run.completed">>;
 
@@ -46,6 +58,6 @@ export const RunFailedSchema = CloudEventContextSchema.merge(RunContextSchema)
       entity: z.undefined().optional(),
       action: z.literal("failed"),
       data: RunFailedDataSchema,
-    })
+    }),
   )
   .strict() satisfies z.ZodType<AnyEvent<"run.failed">>;

--- a/packages/ports/src/engine/flow-router.ts
+++ b/packages/ports/src/engine/flow-router.ts
@@ -1,4 +1,4 @@
-import { RunContext } from "@lcase/types/engine";
+import { RunContext } from "@lcase/types";
 
 export type RouterActions = {};
 

--- a/packages/ports/src/engine/run-orchestrator.port.ts
+++ b/packages/ports/src/engine/run-orchestrator.port.ts
@@ -1,4 +1,4 @@
-import { RunContext } from "@lcase/types/engine";
+import { RunContext } from "@lcase/types";
 
 export interface RunOrchestratorPort {
   handleStepOutcome(outcome: StepOutcome, ctx: RunContext): void;

--- a/packages/ports/src/engine/step-handler.port.ts
+++ b/packages/ports/src/engine/step-handler.port.ts
@@ -1,5 +1,5 @@
 import { FlowDefinition } from "@lcase/types";
-import { RunContext, StepContext } from "@lcase/types/engine";
+import { RunContext, StepContext } from "@lcase/types";
 import { JobEmitterPort } from "../events/emitters.port.js";
 import { StepOutcome } from "../engine.port.js";
 
@@ -9,7 +9,7 @@ export interface StepHandlerPort {
     flow: FlowDefinition,
     context: RunContext,
     stepName: string,
-    emitter: JobEmitterPort
+    emitter: JobEmitterPort,
   ): Promise<void>;
   // handleNew(
   //   runCtx: RunContext,

--- a/packages/ports/src/engine/step-runner.port.ts
+++ b/packages/ports/src/engine/step-runner.port.ts
@@ -1,4 +1,4 @@
-import { RunContext, StepContext } from "@lcase/types/engine";
+import { RunContext, StepContext } from "@lcase/types";
 
 export interface StepRunnerPort {
   run(context: RunContext, stepId: string): void;

--- a/packages/ports/src/engine/telemetry.port.ts
+++ b/packages/ports/src/engine/telemetry.port.ts
@@ -1,5 +1,5 @@
 import type { FlowEvent, FlowEventType } from "@lcase/types";
-import type { FlowContext, RunContext } from "@lcase/types/engine";
+import type { FlowContext, RunContext } from "@lcase/types";
 import { FlowQueuedParsed } from "../events/flow-parser.port.js";
 
 type thing = {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,9 +6,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts"
-    },
-    "./engine": {
-      "types": "./dist/engine/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/types/src/engine/fork-spec.type.ts
+++ b/packages/types/src/engine/fork-spec.type.ts
@@ -1,0 +1,1 @@
+export type ForkSpec = {};

--- a/packages/types/src/engine/fork-spec.type.ts
+++ b/packages/types/src/engine/fork-spec.type.ts
@@ -1,1 +1,23 @@
-export type ForkSpec = {};
+type OutputHash = string;
+type StepId = string;
+
+/**
+ * Spec for deriving run behavior.
+ * Currently has properties more specific to a Simulation Spec, in terms
+ * of execution details, but for now we are just modeling a specific case
+ * when forking an existing run + simulation in one type.
+ */
+export type ForkSpec = {
+  parentRunId: string;
+  flowDefMode: FlowDefMode;
+  forceRerunSteps: string[];
+  cascade: boolean;
+  stepOutputOverrides?: Record<StepId, OutputHash>;
+};
+
+export type FlowDefMode =
+  | { mode: "inherit" }
+  | {
+      mode: "override";
+      hash: string;
+    };

--- a/packages/types/src/engine/fork-spec.type.ts
+++ b/packages/types/src/engine/fork-spec.type.ts
@@ -2,10 +2,11 @@ type OutputHash = string;
 type StepId = string;
 
 /**
- * Spec for deriving run behavior.
+ * Spec for deriving forked run behavior.
  * Currently has properties more specific to a Simulation Spec, in terms
  * of execution details, but for now we are just modeling a specific case
- * when forking an existing run + simulation in one type.
+ * when forking an existing run + simulation in one type.  May become a
+ * broaders simulation spec over time.
  */
 export type ForkSpec = {
   parentRunId: string;

--- a/packages/types/src/engine/index.ts
+++ b/packages/types/src/engine/index.ts
@@ -1,1 +1,0 @@
-export * from "./run-context.js";

--- a/packages/types/src/events/run/data.ts
+++ b/packages/types/src/events/run/data.ts
@@ -7,7 +7,10 @@ type RunDescriptor = {
     id: string;
   };
 };
-
+export type RunRequestedData = {
+  flowDefHash: string;
+  forkSpecHash?: string;
+};
 export type RunStartedData = null;
 export type RunCompletedData = null;
 export type RunFailedData = null;

--- a/packages/types/src/events/run/map.ts
+++ b/packages/types/src/events/run/map.ts
@@ -1,11 +1,13 @@
 import type {
   RunCompletedData,
   RunFailedData,
+  RunRequestedData,
   RunStartedData,
 } from "./data.js";
 import type { DomainActionDescriptor } from "../shared/otel-attributes.js";
 
 export type RunEventMap = {
+  "run.requested": DomainActionDescriptor<"run", "requested", RunRequestedData>;
   "run.started": DomainActionDescriptor<"run", "started", RunStartedData>;
   "run.completed": DomainActionDescriptor<"run", "completed", RunCompletedData>;
   "run.failed": DomainActionDescriptor<"run", "failed", RunFailedData>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,3 +37,5 @@ export * from "./tool/tool.types.js";
 
 export * from "./worker/metadata.js";
 export * from "./flow-analysis/types.js";
+export * from "./engine/fork-spec.type.js";
+export * from "./engine/run-context.js";


### PR DESCRIPTION
## Summary

Implement a ForkSpec object type and attach to a `run.requested` event.

## Related Issues

- #179 

## Changes

- Change out `engine` types are exported from `@lcase/types`.  Use just a barrel, not sub folder export path.  (import from `@lcase/types` not `@lcase/types/engine` in other packages)
- Implement initial `ForkSpec` type.
- Create a new event type `run.requested` which provides CAS hash for the flow definition and fork spec.