### PR TITLE
feat: add run index store + reader

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -35,6 +35,10 @@
     "./artifact-store": {
       "types": "./dist/artifact-store/index.d.ts",
       "import": "./dist/artifact-store/index.js"
+    },
+    "./run-index-store": {
+      "types": "./dist/run-index-store/index.d.ts",
+      "import": "./dist/run-index-store/index.js"
     }
   },
   "scripts": {

--- a/packages/adapters/src/run-index-store/fs-run-index-store.ts
+++ b/packages/adapters/src/run-index-store/fs-run-index-store.ts
@@ -1,134 +1,17 @@
 import type { RunIndex, RunIndexStorePort } from "@lcase/ports";
-import type { AnyEvent } from "@lcase/types";
 import fs from "node:fs";
 import path from "node:path";
 
-type RunId = string;
-type RunScopedEvent = AnyEvent & { runid: string };
-
-type ProcessedEvent =
-  | AnyEvent<"run.requested">
-  | AnyEvent<"run.started">
-  | AnyEvent<"run.completed">
-  | AnyEvent<"run.failed">
-  | AnyEvent<"step.started">
-  | AnyEvent<"step.completed">
-  | AnyEvent<"step.failed">;
-
 export class FsRunIndexStore implements RunIndexStorePort {
-  private runIndexes = new Map<RunId, RunIndex>();
   constructor(public dir: string) {
     if (!path.isAbsolute(dir) || path.extname(dir) !== "") {
       throw new Error(
-        `[fs-run-index-store] must supply an absolute dir path: ${dir}`,
+        `[fs-run-index-store] path must point to an absolute directory: ${dir}`,
       );
     }
-    console.log("dir:", dir);
-    if (!fs.existsSync(dir)) {
-      console.log("making dir");
-
-      fs.mkdirSync(dir, { recursive: true });
-    }
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   }
-
-  async processEvent(event: AnyEvent): Promise<void> {
-    if (!this.hasRunId(event)) return;
-
-    switch (event.type) {
-      case "run.requested":
-        this.processRunRequested(event as AnyEvent<"run.requested">);
-        break;
-      case "run.started":
-        this.processRunStarted(event as AnyEvent<"run.started">);
-        break;
-      case "run.completed":
-        this.processRunFinished(event as AnyEvent<"run.completed">);
-        break;
-      case "run.failed":
-        this.processRunFinished(event as AnyEvent<"run.failed">);
-        break;
-      case "step.started":
-        this.processStepStarted(event as AnyEvent<"step.started">);
-        break;
-      case "step.completed":
-        this.processStepFinished(event as AnyEvent<"step.completed">);
-        break;
-      case "step.failed":
-        this.processStepFinished(event as AnyEvent<"step.failed">);
-        break;
-      default:
-        break;
-    }
-  }
-
-  initRunIndex(event: ProcessedEvent): RunIndex {
-    const index: RunIndex = {
-      flowId: event.flowid,
-      traceId: event.traceid,
-      steps: {},
-    };
-    this.runIndexes.set(event.runid, index);
-    return index;
-  }
-
-  getIndex(event: ProcessedEvent) {
-    return this.runIndexes.get(event.runid) ?? this.initRunIndex(event);
-  }
-
-  processRunRequested(event: AnyEvent<"run.requested">) {
-    const index = this.getIndex(event);
-    index.flowDefHash = event.data.flowDefHash;
-    index.forkSpecHash = event.data.forkSpecHash;
-  }
-  processRunStarted(event: AnyEvent<"run.started">): void {
-    const index = this.getIndex(event);
-    index.startTime = event.time;
-  }
-  processRunFinished(
-    event: AnyEvent<"run.completed"> | AnyEvent<"run.failed">,
-  ): void {
-    const index = this.getIndex(event);
-    index.endTime = event.time;
-    index.duration = this.getDuration(index.startTime, index.endTime);
-    this.writeRunIndex(event.runid, index);
-  }
-  processStepStarted(event: AnyEvent<"step.started">): void {
-    const index = this.getIndex(event);
-    index.steps[event.stepid] ??= {};
-    index.steps[event.stepid].startTime = event.time;
-    index.steps[event.stepid].status = event.data.status;
-  }
-  processStepFinished(
-    event: AnyEvent<"step.completed"> | AnyEvent<"step.failed">,
-  ): void {
-    const index = this.getIndex(event);
-    index.steps[event.stepid] ??= {};
-    const step = index.steps[event.stepid];
-    step.endTime = event.time;
-    step.outputHash = event.data.outputHash;
-    step.status = event.data.status;
-    step.duration = this.getDuration(step.startTime, step.endTime);
-  }
-
-  hasRunId(event: AnyEvent): event is RunScopedEvent {
-    const e = event as unknown as Record<string, unknown>;
-    return typeof e.runid === "string";
-  }
-
-  getDuration(
-    startTime: string | undefined,
-    endTime: string | undefined,
-  ): number | undefined {
-    if (startTime === undefined || endTime === undefined) return;
-    const startDate = new Date(startTime);
-    const endDate = new Date(endTime);
-    const duration = endDate.getTime() - startDate.getTime();
-    if (Number.isNaN(duration)) return;
-
-    return Math.abs(duration) / 1000;
-  }
-
-  writeRunIndex(runId: string, index: RunIndex) {
+  async putRunIndex(index: RunIndex, runId: string): Promise<void> {
     try {
       const json = JSON.stringify(index, null, 2);
       const fileName = `${runId}.index.json`;
@@ -137,5 +20,9 @@ export class FsRunIndexStore implements RunIndexStorePort {
     } catch (e) {
       console.log("Error writing run index", e);
     }
+    return;
+  }
+  getRunIndex(runId: string): Promise<RunIndex | undefined> {
+    throw new Error("Method not implemented.");
   }
 }

--- a/packages/adapters/src/run-index-store/fs-run-index-store.ts
+++ b/packages/adapters/src/run-index-store/fs-run-index-store.ts
@@ -1,0 +1,120 @@
+import type { RunIndex, RunIndexStorePort } from "@lcase/ports";
+import type { AnyEvent } from "@lcase/types";
+import fs, { WriteStream } from "node:fs";
+import path from "node:path";
+
+type RunId = string;
+type RunScopedEvent = AnyEvent & { runid: string };
+
+type ProcessedEvent =
+  | AnyEvent<"run.requested">
+  | AnyEvent<"run.started">
+  | AnyEvent<"run.completed">
+  | AnyEvent<"run.failed">
+  | AnyEvent<"step.started">
+  | AnyEvent<"step.completed">
+  | AnyEvent<"step.failed">;
+
+export class FsRunIndexStore implements RunIndexStorePort {
+  private runIndexes = new Map<RunId, RunIndex>();
+  constructor(public dir: string) {
+    if (!path.isAbsolute(dir)) {
+      throw new Error(`[fs-run-index-store] dir must be absolute: ${dir}`);
+    }
+    if (fs.existsSync(dir))
+      fs.mkdirSync(path.dirname(dir), { recursive: true });
+  }
+
+  async processEvent(event: AnyEvent): Promise<void> {
+    if (!this.hasRunId(event)) return;
+
+    switch (event.type) {
+      case "run.requested":
+        this.processRunRequested(event as AnyEvent<"run.requested">);
+        break;
+      case "run.started":
+        this.processRunStarted(event as AnyEvent<"run.started">);
+        break;
+      case "run.completed":
+        this.processRunFinished(event as AnyEvent<"run.completed">);
+        break;
+      case "run.failed":
+        this.processRunFinished(event as AnyEvent<"run.failed">);
+        break;
+      case "step.started":
+        this.processStepStarted(event as AnyEvent<"step.started">);
+        break;
+      case "step.completed":
+        this.processStepFinished(event as AnyEvent<"step.completed">);
+        break;
+      case "step.failed":
+        this.processStepFinished(event as AnyEvent<"step.failed">);
+        break;
+      default:
+        break;
+    }
+  }
+
+  initRunIndex(event: ProcessedEvent): RunIndex {
+    const index: RunIndex = {
+      flowId: event.flowid,
+      traceId: event.traceid,
+      steps: {},
+    };
+    this.runIndexes.set(event.runid, index);
+    return index;
+  }
+
+  getIndex(event: ProcessedEvent) {
+    return this.runIndexes.get(event.runid) ?? this.initRunIndex(event);
+  }
+
+  processRunRequested(event: AnyEvent<"run.requested">) {
+    const index = this.getIndex(event);
+    index.flowDefHash = event.data.flowDefHash;
+    index.forkSpecHash = event.data.forkSpecHash;
+  }
+  processRunStarted(event: AnyEvent<"run.started">): void {
+    const index = this.getIndex(event);
+    index.startTime = event.time;
+  }
+  processRunFinished(
+    event: AnyEvent<"run.completed"> | AnyEvent<"run.failed">,
+  ): void {
+    const index = this.getIndex(event);
+    index.endTime = event.time;
+    index.duration = this.getDuration(index.startTime, index.endTime);
+  }
+  processStepStarted(event: AnyEvent<"step.started">): void {
+    const index = this.getIndex(event);
+    index.steps[event.stepid].startTime = event.time;
+    index.steps[event.stepid].status = event.data.status;
+  }
+  processStepFinished(
+    event: AnyEvent<"step.completed"> | AnyEvent<"step.failed">,
+  ): void {
+    const step = this.getIndex(event).steps[event.stepid];
+    step.endTime = event.time;
+    step.outputHash = event.data.outputHash;
+    step.status = event.data.status;
+    step.duration = this.getDuration(step.startTime, step.endTime);
+  }
+
+  hasRunId(event: AnyEvent): event is RunScopedEvent {
+    const e = event as unknown as Record<string, unknown>;
+    return typeof e.runid === "string";
+  }
+
+  getDuration(
+    startTime: string | undefined,
+    endTime: string | undefined,
+  ): number | undefined {
+    if (startTime === undefined || endTime === undefined) return;
+    const startDate = new Date(startTime);
+    const endDate = new Date(endTime);
+    const duration = endDate.getTime() - startDate.getTime();
+    if (Number.isNaN(duration)) return;
+
+    return Math.abs(duration) / 1000;
+  }
+}

--- a/packages/adapters/src/run-index-store/fs-run-index-store.ts
+++ b/packages/adapters/src/run-index-store/fs-run-index-store.ts
@@ -22,7 +22,14 @@ export class FsRunIndexStore implements RunIndexStorePort {
     }
     return;
   }
-  getRunIndex(runId: string): Promise<RunIndex | undefined> {
-    throw new Error("Method not implemented.");
+  async getRunIndex(runId: string): Promise<RunIndex | undefined> {
+    try {
+      const fileName = `${runId}.index.json`;
+      const absoluteFilePath = path.join(this.dir, fileName);
+      const data = fs.readFileSync(absoluteFilePath, { encoding: "utf8" });
+      return await JSON.parse(data);
+    } catch (e) {
+      console.log(`Error reading index for run:${runId}. ${e}`);
+    }
   }
 }

--- a/packages/adapters/src/run-index-store/index.ts
+++ b/packages/adapters/src/run-index-store/index.ts
@@ -1,0 +1,1 @@
+export * from "./fs-run-index-store.js";

--- a/packages/adapters/tests/fixtures/run-index-store/run-242b4e22-d5aa-44fc-bec2-f745eb96f605.index.json
+++ b/packages/adapters/tests/fixtures/run-index-store/run-242b4e22-d5aa-44fc-bec2-f745eb96f605.index.json
@@ -1,0 +1,23 @@
+{
+  "flowId": "933dcae021a90ab5df5a5b1b47b590bd",
+  "steps": {
+    "post": {
+      "startTime": "2026-01-23T00:01:08.629Z",
+      "status": "failure",
+      "endTime": "2026-01-23T00:01:38.869Z",
+      "outputHash": "9bee09271b3d182c20418cdef8f094d26eb8b294e502bcf7f549a1f92e80f097",
+      "duration": 30.24
+    },
+    "delete": {
+      "startTime": "2026-01-23T00:01:38.871Z",
+      "status": "success",
+      "endTime": "2026-01-23T00:01:38.984Z",
+      "outputHash": "b128acd98f5fed701c40542d560d85aba2b647fba73bcb0276978dc9289d9b72",
+      "duration": 0.113
+    }
+  },
+  "traceId": "4fc3c54820165b67c8f724f9e3a928bc",
+  "startTime": "2026-01-23T00:01:08.628Z",
+  "endTime": "2026-01-23T00:01:38.984Z",
+  "duration": 30.356
+}

--- a/packages/adapters/tests/run-index-store/fs-run-index-store.test.ts
+++ b/packages/adapters/tests/run-index-store/fs-run-index-store.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { FsRunIndexStore } from "../../src/run-index-store/fs-run-index-store.js";
+import type { RunIndex } from "@lcase/ports";
+import path from "node:path";
+import fs from "node:fs";
+describe("FsRunIndexStore", () => {
+  it("putRunIndex() writes the correct index to the correct path", async () => {
+    const dirPath = import.meta.dirname;
+    const runId = "run-242b4e22-d5aa-44fc-bec2-f745eb96f605";
+    const store = new FsRunIndexStore(dirPath);
+    const index: RunIndex = {
+      flowId: "933dcae021a90ab5df5a5b1b47b590bd",
+      steps: {
+        post: {
+          startTime: "2026-01-23T00:01:08.629Z",
+          status: "failure",
+          endTime: "2026-01-23T00:01:38.869Z",
+          outputHash:
+            "9bee09271b3d182c20418cdef8f094d26eb8b294e502bcf7f549a1f92e80f097",
+          duration: 30.24,
+        },
+        delete: {
+          startTime: "2026-01-23T00:01:38.871Z",
+          status: "success",
+          endTime: "2026-01-23T00:01:38.984Z",
+          outputHash:
+            "b128acd98f5fed701c40542d560d85aba2b647fba73bcb0276978dc9289d9b72",
+          duration: 0.113,
+        },
+      },
+      traceId: "4fc3c54820165b67c8f724f9e3a928bc",
+      startTime: "2026-01-23T00:01:08.628Z",
+      endTime: "2026-01-23T00:01:38.984Z",
+      duration: 30.356,
+    };
+    await store.putRunIndex(index, runId);
+    const expectedFilePath = path.join(dirPath, `${runId}.index.json`);
+    const data = fs.readFileSync(expectedFilePath, {
+      encoding: "utf8",
+    });
+    fs.unlinkSync(expectedFilePath);
+    const json = await JSON.parse(data);
+    expect(json).toEqual(index);
+  });
+  it("getRunIndex() reads the expected index", async () => {
+    const dirPath = path.resolve(
+      import.meta.dirname,
+      "../fixtures/run-index-store",
+    );
+    const runId = "run-242b4e22-d5aa-44fc-bec2-f745eb96f605";
+    const store = new FsRunIndexStore(dirPath);
+    const index = await store.getRunIndex(runId);
+    const expectedIndex: RunIndex = {
+      flowId: "933dcae021a90ab5df5a5b1b47b590bd",
+      steps: {
+        post: {
+          startTime: "2026-01-23T00:01:08.629Z",
+          status: "failure",
+          endTime: "2026-01-23T00:01:38.869Z",
+          outputHash:
+            "9bee09271b3d182c20418cdef8f094d26eb8b294e502bcf7f549a1f92e80f097",
+          duration: 30.24,
+        },
+        delete: {
+          startTime: "2026-01-23T00:01:38.871Z",
+          status: "success",
+          endTime: "2026-01-23T00:01:38.984Z",
+          outputHash:
+            "b128acd98f5fed701c40542d560d85aba2b647fba73bcb0276978dc9289d9b72",
+          duration: 0.113,
+        },
+      },
+      traceId: "4fc3c54820165b67c8f724f9e3a928bc",
+      startTime: "2026-01-23T00:01:08.628Z",
+      endTime: "2026-01-23T00:01:38.984Z",
+      duration: 30.356,
+    };
+
+    expect(index).toEqual(expectedIndex);
+  });
+});

--- a/packages/app-services/run-history/package.json
+++ b/packages/app-services/run-history/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@lcase/observability",
-  "version": "0.1.0-alpha.8",
+  "name": "@lcase/run-history",
+  "version": "0.1.0-alpha.9",
   "private": true,
   "type": "module",
   "exports": {
@@ -12,20 +12,14 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "echo test",
-    "lint": "echo lint",
-    "clean-dist": "rm -rf ./dist",
-    "clean-node-modules": "rm -rf ./node_modules"
+    "test": "vitest",
+    "lint": "echo lint"
   },
   "packageManager": "pnpm@10.17.1",
-  "dependencies": {
-    "ws": "^8.18.3",
-    "@lcase/run-history": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@lcase/ports": "workspace:*",
     "@lcase/types": "workspace:*",
-    "@types/ws": "^8.18.1",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/app-services/run-history/src/get-step-output-hashes.ts
+++ b/packages/app-services/run-history/src/get-step-output-hashes.ts
@@ -1,0 +1,1 @@
+export function getStepOutputHashes(stepIds: string[], runId: string) {}

--- a/packages/app-services/run-history/src/get-step-output-hashes.ts
+++ b/packages/app-services/run-history/src/get-step-output-hashes.ts
@@ -3,6 +3,13 @@ import type { RunIndexStorePort } from "@lcase/ports";
 type RunId = string;
 type OutputHash = string;
 
+/**
+ * Gets the output hashes for a list of steps.
+ * @param stepIds array of step ids to get output hashes from
+ * @param runId run id string of the run
+ * @param store store implementation for retrieving the run index
+ * @returns Record<string, string> ( runId -> outputHash map )
+ */
 export async function getStepOutputHashes(
   stepIds: string[],
   runId: string,

--- a/packages/app-services/run-history/src/get-step-output-hashes.ts
+++ b/packages/app-services/run-history/src/get-step-output-hashes.ts
@@ -1,1 +1,22 @@
-export function getStepOutputHashes(stepIds: string[], runId: string) {}
+import type { RunIndexStorePort } from "@lcase/ports";
+
+type RunId = string;
+type OutputHash = string;
+
+export async function getStepOutputHashes(
+  stepIds: string[],
+  runId: string,
+  store: RunIndexStorePort,
+): Promise<Record<RunId, OutputHash> | undefined> {
+  const json = await store.getRunIndex(runId);
+  if (!json) return;
+
+  const hashMap: Record<RunId, OutputHash> = {};
+
+  for (const stepId of stepIds) {
+    const step = json.steps[stepId];
+    if (!step) return;
+    if (step.outputHash) hashMap[stepId] = step.outputHash;
+  }
+  return hashMap;
+}

--- a/packages/app-services/run-history/src/index.ts
+++ b/packages/app-services/run-history/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./update-run-index.js";
-export * from "./read-run-history.js";
 export * from "./get-step-output-hashes.js";
 export * from "./init-run-index.js";
 export * from "./utils/has-run-id.js";

--- a/packages/app-services/run-history/src/index.ts
+++ b/packages/app-services/run-history/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./update-run-index.js";
+export * from "./read-run-history.js";
+export * from "./get-step-output-hashes.js";
+export * from "./init-run-index.js";
+export * from "./utils/has-run-id.js";

--- a/packages/app-services/run-history/src/init-run-index.ts
+++ b/packages/app-services/run-history/src/init-run-index.ts
@@ -2,6 +2,13 @@ import { RunIndex } from "@lcase/ports";
 import { AnyEvent } from "@lcase/types";
 import { isRunIndexEvent } from "./utils/is-run-index-event.js";
 
+/**
+ * Inits a RunIndex object based on the supplied event, if it is a
+ * event relevant to creating the run index.  If its not relevant, returns
+ * undefined.  If it is, creates the minimum RunIndex from that event's details.
+ * @param event AnyEvent
+ * @returns RunIndex or undefined
+ */
 export function initRunIndex(event: AnyEvent): RunIndex | undefined {
   if (!isRunIndexEvent(event)) return;
   const index: RunIndex = {

--- a/packages/app-services/run-history/src/init-run-index.ts
+++ b/packages/app-services/run-history/src/init-run-index.ts
@@ -1,0 +1,13 @@
+import { RunIndex } from "@lcase/ports";
+import { AnyEvent } from "@lcase/types";
+import { isRunIndexEvent } from "./utils/is-run-index-event.js";
+
+export function initRunIndex(event: AnyEvent): RunIndex | undefined {
+  if (!isRunIndexEvent(event)) return;
+  const index: RunIndex = {
+    flowId: event.flowid,
+    steps: {},
+    traceId: event.traceid,
+  };
+  return index;
+}

--- a/packages/app-services/run-history/src/list-completed-steps.ts
+++ b/packages/app-services/run-history/src/list-completed-steps.ts
@@ -1,0 +1,16 @@
+import type { RunIndex } from "@lcase/ports";
+
+/**
+ * Looks through a run index and returns a list of step ids who's stats
+ * is equal to "success".
+ *
+ * @param index RunIndex
+ * @returns string[] (array of stepId strings)
+ */
+export function listCompletedSteps(index: RunIndex): string[] {
+  const steps: string[] = [];
+  for (const stepId in index.steps) {
+    if (index.steps[stepId].status === "success") steps.push(stepId);
+  }
+  return steps;
+}

--- a/packages/app-services/run-history/src/read-run-history.ts
+++ b/packages/app-services/run-history/src/read-run-history.ts
@@ -1,3 +1,0 @@
-import type { RunIndexStorePort } from "@lcase/ports";
-
-export function readRunHistory(runId: string, store: RunIndexStorePort) {}

--- a/packages/app-services/run-history/src/read-run-history.ts
+++ b/packages/app-services/run-history/src/read-run-history.ts
@@ -1,0 +1,3 @@
+import type { RunIndexStorePort } from "@lcase/ports";
+
+export function readRunHistory(runId: string, store: RunIndexStorePort) {}

--- a/packages/app-services/run-history/src/update-run-index.ts
+++ b/packages/app-services/run-history/src/update-run-index.ts
@@ -10,21 +10,9 @@ import {
 } from "./utils/process.js";
 import { initRunIndex } from "./init-run-index.js";
 
-type RunId = string;
-type RunScopedEvent = AnyEvent & { runid: string };
-
-type RunIndexEvent =
-  | AnyEvent<"run.requested">
-  | AnyEvent<"run.started">
-  | AnyEvent<"run.completed">
-  | AnyEvent<"run.failed">
-  | AnyEvent<"step.started">
-  | AnyEvent<"step.completed">
-  | AnyEvent<"step.failed">;
-
 export function updateRunIndex(
   event: AnyEvent,
-  index: RunIndex | undefined,
+  index?: RunIndex,
 ): RunIndex | undefined {
   if (!hasRunId(event)) return;
   index ??= initRunIndex(event);

--- a/packages/app-services/run-history/src/update-run-index.ts
+++ b/packages/app-services/run-history/src/update-run-index.ts
@@ -1,0 +1,58 @@
+import type { AnyEvent } from "@lcase/types";
+import type { RunIndex } from "@lcase/ports";
+import { hasRunId } from "./utils/has-run-id.js";
+import {
+  processRunFinished,
+  processRunRequested,
+  processRunStarted,
+  processStepFinished,
+  processStepStarted,
+} from "./utils/process.js";
+import { initRunIndex } from "./init-run-index.js";
+
+type RunId = string;
+type RunScopedEvent = AnyEvent & { runid: string };
+
+type RunIndexEvent =
+  | AnyEvent<"run.requested">
+  | AnyEvent<"run.started">
+  | AnyEvent<"run.completed">
+  | AnyEvent<"run.failed">
+  | AnyEvent<"step.started">
+  | AnyEvent<"step.completed">
+  | AnyEvent<"step.failed">;
+
+export function updateRunIndex(
+  event: AnyEvent,
+  index: RunIndex | undefined,
+): RunIndex | undefined {
+  if (!hasRunId(event)) return;
+  index ??= initRunIndex(event);
+  if (!index) return;
+  switch (event.type) {
+    case "run.requested":
+      processRunRequested(event as AnyEvent<"run.requested">, index);
+      break;
+    case "run.started":
+      processRunStarted(event as AnyEvent<"run.started">, index);
+      break;
+    case "run.completed":
+      processRunFinished(event as AnyEvent<"run.completed">, index);
+      break;
+    case "run.failed":
+      processRunFinished(event as AnyEvent<"run.failed">, index);
+      break;
+    case "step.started":
+      processStepStarted(event as AnyEvent<"step.started">, index);
+      break;
+    case "step.completed":
+      processStepFinished(event as AnyEvent<"step.completed">, index);
+      break;
+    case "step.failed":
+      processStepFinished(event as AnyEvent<"step.failed">, index);
+      break;
+    default:
+      break;
+  }
+  return index;
+}

--- a/packages/app-services/run-history/src/update-run-index.ts
+++ b/packages/app-services/run-history/src/update-run-index.ts
@@ -10,11 +10,33 @@ import {
 } from "./utils/process.js";
 import { initRunIndex } from "./init-run-index.js";
 
+/**
+ * Updates a RunIndex object given a certain event.
+ *
+ * If the RunIndex object is undefined, it will attempt to create it
+ * from the event provided.  Otherwise it will mutate + return the index.
+ * If the event supplies is not relevant, returns the original index supplied
+ * without changes.
+ *
+ * This behavior is a bit odd for the function name but it works in the
+ * observability sink, and streamlines some behavior.  Probably think about
+ * refactoring this to be clearer about what actually gets mutated/returned.
+ *
+ * But its designed to be flexible for undefined index values and add
+ * information to an index by events, even if the events are out of order.
+ *
+ * Invokes a few utility functions that apply very simple granular edits
+ * to the RunIndex.  Easier just to mutate in place, but unsure if it should
+ * work this way.
+ * @param event AnyEvent in the event system
+ * @param index A RunIndex object, optional
+ * @returns RunIndex or undefined
+ */
 export function updateRunIndex(
   event: AnyEvent,
   index?: RunIndex,
 ): RunIndex | undefined {
-  if (!hasRunId(event)) return;
+  if (!hasRunId(event)) return index;
   index ??= initRunIndex(event);
   if (!index) return;
   switch (event.type) {

--- a/packages/app-services/run-history/src/utils/get-duration.ts
+++ b/packages/app-services/run-history/src/utils/get-duration.ts
@@ -1,0 +1,12 @@
+export function getDuration(
+  startTime: string | undefined,
+  endTime: string | undefined,
+): number | undefined {
+  if (startTime === undefined || endTime === undefined) return;
+  const startDate = new Date(startTime);
+  const endDate = new Date(endTime);
+  const duration = endDate.getTime() - startDate.getTime();
+  if (Number.isNaN(duration)) return;
+
+  return Math.abs(duration) / 1000;
+}

--- a/packages/app-services/run-history/src/utils/get-duration.ts
+++ b/packages/app-services/run-history/src/utils/get-duration.ts
@@ -1,3 +1,15 @@
+/**
+ * Finds the duration between two date ISO strings in seconds.
+ * If strings and undefined, does not subtract them.  Will also return undefined
+ * if subtraction produces NaN.  Takes the absolute value of the final result
+ * and converts to seconds.
+ *
+ * Used in quickly storing duration information in a RunIndex object.
+ * @param startTime ISO date string
+ * @param endTime ISO date string
+ * @returns Duration in seconds or undefined
+ */
+
 export function getDuration(
   startTime: string | undefined,
   endTime: string | undefined,

--- a/packages/app-services/run-history/src/utils/has-run-id.ts
+++ b/packages/app-services/run-history/src/utils/has-run-id.ts
@@ -1,0 +1,7 @@
+import { AnyEvent } from "@lcase/types";
+
+type RunScopedEvent = AnyEvent & { runid: string };
+export function hasRunId(event: AnyEvent): event is RunScopedEvent {
+  const e = event as unknown as Record<string, unknown>;
+  return typeof e.runid === "string";
+}

--- a/packages/app-services/run-history/src/utils/has-run-id.ts
+++ b/packages/app-services/run-history/src/utils/has-run-id.ts
@@ -1,6 +1,14 @@
 import { AnyEvent } from "@lcase/types";
 
 type RunScopedEvent = AnyEvent & { runid: string };
+
+/**
+ * Used to quickly see if an event is a RunScopedEvent type or not, meaning it
+ * has a runid in its payload.  Also helps narrow it to that type for TypeScript
+ * ahead of runtime.
+ * @param event AnyEvent
+ * @returns true if the event has a run id, with type narrowing as a RunScopedEvent
+ */
 export function hasRunId(event: AnyEvent): event is RunScopedEvent {
   const e = event as unknown as Record<string, unknown>;
   return typeof e.runid === "string";

--- a/packages/app-services/run-history/src/utils/is-run-index-event.ts
+++ b/packages/app-services/run-history/src/utils/is-run-index-event.ts
@@ -1,0 +1,16 @@
+import { RunIndexEvent } from "@lcase/ports";
+import { AnyEvent } from "@lcase/types";
+
+const eventTypes = new Set([
+  "run.requested",
+  "run.started",
+  "run.completed",
+  "run.failed",
+  "step.started",
+  "step.completed",
+  "step.failed",
+]);
+
+export function isRunIndexEvent(event: AnyEvent): event is RunIndexEvent {
+  return eventTypes.has(event.type);
+}

--- a/packages/app-services/run-history/src/utils/is-run-index-event.ts
+++ b/packages/app-services/run-history/src/utils/is-run-index-event.ts
@@ -11,6 +11,13 @@ const eventTypes = new Set([
   "step.failed",
 ]);
 
+/**
+ * Looks at the event type of the supplied event, and sees if its a member
+ * of the set of events that are relevant to building a RunIndex.  If it is,
+ * returns true, and narrows the event type to a RunIndexEvent.
+ * @param event AnyEvent
+ * @returns boolean
+ */
 export function isRunIndexEvent(event: AnyEvent): event is RunIndexEvent {
   return eventTypes.has(event.type);
 }

--- a/packages/app-services/run-history/src/utils/process.ts
+++ b/packages/app-services/run-history/src/utils/process.ts
@@ -2,6 +2,10 @@ import { RunIndex } from "@lcase/ports";
 import { AnyEvent } from "@lcase/types";
 import { getDuration } from "./get-duration.js";
 
+/**
+ * A few function that mutate a supplied based on the event it receives.
+ */
+
 export function processRunRequested(
   event: AnyEvent<"run.requested">,
   index: RunIndex,

--- a/packages/app-services/run-history/src/utils/process.ts
+++ b/packages/app-services/run-history/src/utils/process.ts
@@ -1,0 +1,46 @@
+import { RunIndex } from "@lcase/ports";
+import { AnyEvent } from "@lcase/types";
+import { getDuration } from "./get-duration.js";
+
+export function processRunRequested(
+  event: AnyEvent<"run.requested">,
+  index: RunIndex,
+) {
+  index.flowDefHash = event.data.flowDefHash;
+  index.forkSpecHash = event.data.forkSpecHash;
+}
+export function processRunStarted(
+  event: AnyEvent<"run.started">,
+  index: RunIndex,
+): void {
+  index.startTime = event.time;
+}
+
+export function processRunFinished(
+  event: AnyEvent<"run.completed"> | AnyEvent<"run.failed">,
+  index: RunIndex,
+): void {
+  index.endTime = event.time;
+  index.duration = getDuration(index.startTime, index.endTime);
+}
+
+export function processStepStarted(
+  event: AnyEvent<"step.started">,
+  index: RunIndex,
+): void {
+  index.steps[event.stepid] ??= {};
+  index.steps[event.stepid].startTime = event.time;
+  index.steps[event.stepid].status = event.data.status;
+}
+
+export function processStepFinished(
+  event: AnyEvent<"step.completed"> | AnyEvent<"step.failed">,
+  index: RunIndex,
+): void {
+  index.steps[event.stepid] ??= {};
+  const step = index.steps[event.stepid];
+  step.endTime = event.time;
+  step.outputHash = event.data.outputHash;
+  step.status = event.data.status;
+  step.duration = getDuration(step.startTime, step.endTime);
+}

--- a/packages/app-services/run-history/tests/get-step-output-hashes.test.ts
+++ b/packages/app-services/run-history/tests/get-step-output-hashes.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { getStepOutputHashes } from "../src/get-step-output-hashes.js";
+import { RunIndex, RunIndexStorePort } from "@lcase/ports";
+describe("run-history getStepOutputHashes()", () => {
+  it("returns the correct step hashes from a list of steps", async () => {
+    const index: RunIndex = {
+      flowId: "",
+      traceId: "",
+      steps: {
+        a: {
+          outputHash: "test-hash-a",
+        },
+        b: {
+          outputHash: "test-hash-b",
+        },
+        c: {
+          outputHash: "test-hash-c",
+        },
+      },
+    };
+
+    const getRunIndex = vi.fn().mockReturnValue(index);
+    const store = { getRunIndex } as unknown as RunIndexStorePort;
+
+    const result = await getStepOutputHashes(["a", "b"], "test-runid", store);
+
+    const expectedResult = {
+      a: "test-hash-a",
+      b: "test-hash-b",
+    };
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/packages/app-services/run-history/tests/init-run-index.test.ts
+++ b/packages/app-services/run-history/tests/init-run-index.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { initRunIndex } from "../src/init-run-index.js";
+import type { AnyEvent } from "@lcase/types";
+import { RunIndex } from "@lcase/ports";
+
+describe("run-history initRunIndex()", () => {
+  it("generates a valid run index when given a valid", () => {
+    const event = {
+      id: "test-id",
+      source: "test-source",
+      specversion: "1.0",
+      time: "test-time",
+      type: "run.requested",
+      data: {
+        flowDefHash: "test-flowdefhash",
+        forkSpecHash: undefined,
+      },
+      domain: "run",
+      action: "requested",
+      traceparent: "test-traceparent",
+      traceid: "test-traceid",
+      spanid: "test-spanid",
+      flowid: "test-flowid",
+      runid: "test-runid",
+    } satisfies AnyEvent<"run.requested">;
+
+    const index = initRunIndex(event);
+    const expectedIndex: RunIndex = {
+      flowId: "test-flowid",
+      steps: {},
+      traceId: "test-traceid",
+    };
+    expect(index).toEqual(expectedIndex);
+  });
+  it("returned undefined when given an invalid event", () => {
+    const event = {
+      id: "test-id",
+      source: "test-source",
+      specversion: "1.0",
+      time: "test-time",
+      type: "flow.submitted",
+      data: {
+        definition: {
+          name: "",
+          version: "",
+          start: "",
+          steps: {},
+        },
+        flow: {
+          id: "",
+          name: "",
+          version: "",
+        },
+        inputs: {},
+        run: {
+          id: "",
+        },
+      },
+      domain: "flow",
+      action: "submitted",
+      traceparent: "test-traceparent",
+      traceid: "test-traceid",
+      spanid: "test-spanid",
+      flowid: "test-flowid",
+      runid: "test-runid",
+    } satisfies AnyEvent<"flow.submitted">;
+
+    const index = initRunIndex(event);
+    expect(index).toBe(undefined);
+  });
+});

--- a/packages/app-services/run-history/tests/list-completed-steps.test.ts
+++ b/packages/app-services/run-history/tests/list-completed-steps.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { RunIndex } from "@lcase/ports";
+import { listCompletedSteps } from "../src/list-completed-steps.js";
+describe("run-history listCompletedSteps()", () => {
+  it("returns the correct step hashes from a list of steps", async () => {
+    const index: RunIndex = {
+      flowId: "",
+      traceId: "",
+      steps: {
+        a: {
+          outputHash: "test-hash-a",
+          status: "failed",
+        },
+        b: {
+          outputHash: "test-hash-b",
+          status: "success",
+        },
+        c: {
+          outputHash: "test-hash-c",
+          status: "success",
+        },
+      },
+    };
+    const steps = listCompletedSteps(index);
+
+    expect(steps).toEqual(["b", "c"]);
+  });
+});

--- a/packages/app-services/run-history/tests/update-run-index.test.ts
+++ b/packages/app-services/run-history/tests/update-run-index.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { updateRunIndex } from "../src/update-run-index.js";
+import { AnyEvent } from "@lcase/types";
+import { RunIndex } from "@lcase/ports";
+describe("run-history updateRunIndex()", () => {
+  it("processes a run.requested event correctly", () => {
+    const runRequested = {
+      type: "run.requested",
+      flowid: "test-flowid",
+      runid: "test-runid",
+      traceid: "test-traceid",
+      data: {
+        flowDefHash: "test-flowdefhash",
+        forkSpecHash: "test-forkspechash",
+      },
+    } as unknown as AnyEvent<"run.requested">;
+
+    const index = updateRunIndex(runRequested, undefined);
+    const expectedIndex: RunIndex = {
+      flowId: "test-flowid",
+      steps: {},
+      traceId: "test-traceid",
+      flowDefHash: "test-flowdefhash",
+      forkSpecHash: "test-forkspechash",
+    };
+    expect(index).toEqual(expectedIndex);
+  });
+
+  it("processes a run.started event correctly", () => {
+    const stepStarted = {
+      type: "run.started",
+      flowid: "test-flowid",
+      runid: "test-runid",
+      traceid: "test-traceid",
+      time: "test-time",
+
+      data: {
+        status: "started",
+      },
+    } as unknown as AnyEvent<"run.started">;
+
+    const index = updateRunIndex(stepStarted);
+    const expectedIndex: RunIndex = {
+      flowId: "test-flowid",
+      startTime: "test-time",
+      steps: {},
+      traceId: "test-traceid",
+    };
+    expect(index).toEqual(expectedIndex);
+  });
+
+  it("processes a run.completed event correctly", () => {
+    const stepStarted = {
+      type: "run.completed",
+      flowid: "test-flowid",
+      runid: "test-runid",
+      traceid: "test-traceid",
+      time: "test-time",
+
+      data: {
+        status: "started",
+      },
+    } as unknown as AnyEvent<"run.completed">;
+
+    const index = updateRunIndex(stepStarted);
+    const expectedIndex: RunIndex = {
+      flowId: "test-flowid",
+      endTime: "test-time",
+      steps: {},
+      traceId: "test-traceid",
+    };
+    expect(index).toEqual(expectedIndex);
+  });
+
+  it("processes a step.started event correctly", () => {
+    const stepStarted = {
+      type: "step.started",
+      flowid: "test-flowid",
+      runid: "test-runid",
+      traceid: "test-traceid",
+      time: "test-time",
+      stepid: "test-stepid",
+      data: {
+        status: "started",
+      },
+    } as unknown as AnyEvent<"step.started">;
+
+    const index = updateRunIndex(stepStarted);
+    const expectedIndex: RunIndex = {
+      flowId: "test-flowid",
+      steps: {
+        "test-stepid": {
+          startTime: "test-time",
+          status: "started",
+        },
+      },
+      traceId: "test-traceid",
+    };
+    expect(index).toEqual(expectedIndex);
+  });
+
+  it("processes a step.completed event correctly", () => {
+    const stepStarted = {
+      type: "step.completed",
+      flowid: "test-flowid",
+      runid: "test-runid",
+      traceid: "test-traceid",
+      time: "test-time",
+      stepid: "test-stepid",
+      data: {
+        status: "success",
+      },
+    } as unknown as AnyEvent<"step.completed">;
+
+    const index = updateRunIndex(stepStarted);
+    const expectedIndex: RunIndex = {
+      flowId: "test-flowid",
+      steps: {
+        "test-stepid": {
+          endTime: "test-time",
+          status: "success",
+        },
+      },
+      traceId: "test-traceid",
+    };
+    expect(index).toEqual(expectedIndex);
+  });
+});

--- a/packages/app-services/run-history/tsconfig.json
+++ b/packages/app-services/run-history/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/app-services/run-history/vitest.config.ts
+++ b/packages/app-services/run-history/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.[jt]s"],
+    exclude: ["node_modules", "dist", ".turbo"],
+  },
+});

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -21,6 +21,7 @@
     "@lcase/specs": "workspace:*",
     "@lcase/flow-analysis": "workspace:*",
     "@lcase/json-ref-binder": "workspace:*",
+    "@lcase/run-history": "workspace:*",
     "immer": "^11.0.1"
   },
   "devDependencies": {

--- a/packages/engine/src/effects/get-step-output-hashes.effect.ts
+++ b/packages/engine/src/effects/get-step-output-hashes.effect.ts
@@ -1,0 +1,17 @@
+import type {
+  EffectHandler,
+  EffectHandlerDeps,
+  EmitFlowAnalyzedFx,
+} from "../engine.types.js";
+import { getStepOutputHashes } from "@lcase/run-history";
+
+export const emitFlowAnalyzedFx: EffectHandler<"EmitFlowAnalyzed"> = async (
+  effect: EmitFlowAnalyzedFx,
+  deps: EffectHandlerDeps,
+) => {
+  const hashes = await getStepOutputHashes(
+    ["stepId"],
+    "runId",
+    deps.runIndexStore,
+  );
+};

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -57,7 +57,11 @@ export class Engine {
     this.ef = this.deps.ef;
     this.jobParser = this.deps.jobParser;
 
-    this.handlers = wireEffectHandlers({ ef: this.ef });
+    this.handlers = wireEffectHandlers({
+      ef: this.ef,
+      runIndexStore: deps.runIndexStore,
+      enqueue: this.enqueue,
+    });
   }
 
   subscribeToTopics(): void {
@@ -74,28 +78,28 @@ export class Engine {
       this.handleJobFinished(e);
     });
     this.bus.subscribe("replay.mode.submitted", async (e: AnyEvent) =>
-      this.handleReplayModeSubmitted(e)
+      this.handleReplayModeSubmitted(e),
     );
     this.bus.subscribe("step.planned", async (e: AnyEvent) =>
-      this.handleStepPlanned(e)
+      this.handleStepPlanned(e),
     );
     this.bus.subscribe("step.started", async (e: AnyEvent) =>
-      this.handleStepStarted(e)
+      this.handleStepStarted(e),
     );
     this.bus.subscribe("step.completed", async (e: AnyEvent) =>
-      this.handleStepFinished(e)
+      this.handleStepFinished(e),
     );
     this.bus.subscribe("step.failed", async (e: AnyEvent) =>
-      this.handleStepFinished(e)
+      this.handleStepFinished(e),
     );
     this.bus.subscribe("run.started", async (e: AnyEvent) =>
-      this.handleRunStarted(e)
+      this.handleRunStarted(e),
     );
     this.bus.subscribe("run.completed", async (e: AnyEvent) =>
-      this.handleRunFinished(e)
+      this.handleRunFinished(e),
     );
     this.bus.subscribe("run.failed", async (e: AnyEvent) =>
-      this.handleRunFinished(e)
+      this.handleRunFinished(e),
     );
   }
 
@@ -154,7 +158,7 @@ export class Engine {
   }
 
   executeEffect<T extends EngineEffect["type"]>(
-    effect: Extract<EngineEffect, { type: T }>
+    effect: Extract<EngineEffect, { type: T }>,
   ): void {
     if (!this.enableSideEffects && effect.type !== "WriteContextToDisk") return;
 

--- a/packages/engine/src/engine.types.ts
+++ b/packages/engine/src/engine.types.ts
@@ -1,4 +1,8 @@
-import type { EmitterFactoryPort, QueuePort } from "@lcase/ports";
+import type {
+  EmitterFactoryPort,
+  QueuePort,
+  RunIndexStorePort,
+} from "@lcase/ports";
 import type {
   AnyEvent,
   CloudScope,
@@ -278,4 +282,6 @@ export type EffectHandlerRegistry = {
 };
 export type EffectHandlerDeps = {
   ef: EmitterFactoryPort;
+  runIndexStore: RunIndexStorePort;
+  enqueue: (message: EngineMessage) => void;
 };

--- a/packages/engine/src/planners/job-finished.planner.ts
+++ b/packages/engine/src/planners/job-finished.planner.ts
@@ -42,6 +42,7 @@ export const jobFinishedPlanner: Planner<JobFinishedMsg> = (
       },
       data: {
         status: "success",
+        outputHash: newRunState.steps[stepId].outputHash ?? undefined,
         step: {
           id: stepId,
           name: stepId,
@@ -67,6 +68,7 @@ export const jobFinishedPlanner: Planner<JobFinishedMsg> = (
       data: {
         reason: e.data.message ?? "",
         status: e.data.status,
+        outputHash: newRunState.steps[stepId].outputHash ?? undefined,
         step: {
           id: stepId,
           name: stepId,

--- a/packages/events/src/schemas/step.data.schema.ts
+++ b/packages/events/src/schemas/step.data.schema.ts
@@ -18,20 +18,22 @@ const RunDescriptorSchema = z.object({
 export const StepStartedDataSchema = RunDescriptorSchema.merge(
   z.object({
     status: z.literal("started"),
-  })
+  }),
 ).strict() satisfies z.ZodType<StepStartedData>;
 
 export const StepCompletedDataSchema = RunDescriptorSchema.merge(
   z.object({
     status: z.literal("success"),
-  })
+    outputHash: z.string().optional(),
+  }),
 ).strict() satisfies z.ZodType<StepCompletedData>;
 
 export const StepFailedDataSchema = RunDescriptorSchema.merge(
   z.object({
     status: z.literal("failure"),
     reason: z.string(),
-  })
+    outputHash: z.string().optional(),
+  }),
 ).strict() satisfies z.ZodType<StepFailedData>;
 
 export const StepPlannedDataSchema = z

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -2,3 +2,4 @@ export * from "./core/tap.js";
 export * from "./sinks/console.sink.js";
 export * from "./sinks/web-socket.server.sink.js";
 export * from "./sinks/replay.sink.js";
+export * from "./sinks/run-index.sink.js";

--- a/packages/observability/src/sinks/run-index.sink.ts
+++ b/packages/observability/src/sinks/run-index.sink.ts
@@ -1,0 +1,17 @@
+import type { EventSink, RunIndexStorePort } from "@lcase/ports";
+import type { AnyEvent } from "@lcase/types";
+
+export class RunIndexSink implements EventSink {
+  id = "run-index-sink";
+  enableSink = true;
+  constructor(private readonly store: RunIndexStorePort) {}
+  async start(): Promise<void> {
+    this.enableSink = true;
+  }
+  async stop(): Promise<void> {
+    this.enableSink = false;
+  }
+  handle(event: AnyEvent): Promise<void> | void {
+    if (this.enableSink === true) this.store.processEvent(event);
+  }
+}

--- a/packages/observability/src/sinks/run-index.sink.ts
+++ b/packages/observability/src/sinks/run-index.sink.ts
@@ -1,9 +1,11 @@
-import type { EventSink, RunIndexStorePort } from "@lcase/ports";
+import type { EventSink, RunIndex, RunIndexStorePort } from "@lcase/ports";
 import type { AnyEvent } from "@lcase/types";
+import { hasRunId, updateRunIndex } from "@lcase/run-history";
 
 export class RunIndexSink implements EventSink {
   id = "run-index-sink";
   enableSink = true;
+  runIndexMap = new Map<string, RunIndex>();
   constructor(private readonly store: RunIndexStorePort) {}
   async start(): Promise<void> {
     this.enableSink = true;
@@ -12,6 +14,15 @@ export class RunIndexSink implements EventSink {
     this.enableSink = false;
   }
   handle(event: AnyEvent): Promise<void> | void {
-    if (this.enableSink === true) this.store.processEvent(event);
+    if (this.enableSink === false) return;
+    if (!hasRunId(event)) return;
+
+    const index = updateRunIndex(event, this.runIndexMap.get(event.runid));
+    if (index === undefined) return;
+    this.runIndexMap.set(event.runid, index);
+
+    if (event.type === "run.completed" || event.type === "run.failed") {
+      this.store.putRunIndex(index, event.runid);
+    }
   }
 }

--- a/packages/ports/src/engine/engine.port.ts
+++ b/packages/ports/src/engine/engine.port.ts
@@ -1,10 +1,12 @@
 import { EventBusPort } from "../bus/event-bus.port.js";
 import { EmitterFactoryPort } from "../events/emitter-factory.port.js";
 import { JobParserPort } from "../events/job-parser.port.js";
+import { RunIndexStorePort } from "../run-index-store/run-index-store.port.js";
 
 export type EngineDeps = {
   bus: EventBusPort;
   ef: EmitterFactoryPort;
   // flowParser: FlowParserPort;
   jobParser: JobParserPort;
+  runIndexStore: RunIndexStorePort;
 };

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -19,3 +19,4 @@ export * from "./concurrency-limiter/concurrency-limiter.port.js";
 export * from "./limiter/limiter.port.js";
 export * from "./artifacts/artifact-store.port.js";
 export * from "./artifacts/artifacts.port.js";
+export * from "./run-index-store/run-index-store.port.js";

--- a/packages/ports/src/run-index-store/run-index-store.port.ts
+++ b/packages/ports/src/run-index-store/run-index-store.port.ts
@@ -1,0 +1,40 @@
+import type {
+  AnyEvent,
+  JobCompletedEvent,
+  JobFailedEvent,
+  JobSubmittedEvent,
+} from "@lcase/types";
+
+export type RunIndex = {
+  flowId: string;
+  traceId: string;
+  flowDefHash: string;
+  forkSpecHash?: string;
+  parentId?: string;
+  startTime: string;
+  endTime: string;
+  steps: Record<
+    string,
+    {
+      outputHash: string;
+      status: string;
+      startTime: string;
+      endTime: string;
+      argsHash?: string;
+    }
+  >;
+};
+
+export interface RunIndexStorePort {
+  addRunRequested(event: AnyEvent<"run.requested">): Promise<void>;
+  addJobSubmitted(event: JobSubmittedEvent): Promise<void>;
+  addJobFinished(event: JobCompletedEvent | JobFailedEvent): Promise<void>;
+  addRunStarted(event: AnyEvent<"run.started">): Promise<void>;
+  addRunFinished(
+    event: AnyEvent<"run.completed"> | AnyEvent<"run.failed">,
+  ): Promise<void>;
+  addStepStarted(event: AnyEvent<"step.started">): Promise<void>;
+  addStepFinished(
+    event: AnyEvent<"step.completed"> | AnyEvent<"step.failed">,
+  ): Promise<void>;
+}

--- a/packages/ports/src/run-index-store/run-index-store.port.ts
+++ b/packages/ports/src/run-index-store/run-index-store.port.ts
@@ -21,7 +21,16 @@ export type RunIndex = {
     }
   >;
 };
+export type RunIndexEvent =
+  | AnyEvent<"run.requested">
+  | AnyEvent<"run.started">
+  | AnyEvent<"run.completed">
+  | AnyEvent<"run.failed">
+  | AnyEvent<"step.started">
+  | AnyEvent<"step.completed">
+  | AnyEvent<"step.failed">;
 
 export interface RunIndexStorePort {
-  processEvent(event: AnyEvent): Promise<void>;
+  putRunIndex(index: RunIndex, runId: string): Promise<void>;
+  getRunIndex(runId: string): Promise<RunIndex | undefined>;
 }

--- a/packages/ports/src/run-index-store/run-index-store.port.ts
+++ b/packages/ports/src/run-index-store/run-index-store.port.ts
@@ -13,7 +13,7 @@ export type RunIndex = {
     string,
     {
       outputHash?: string;
-      status: string;
+      status?: string;
       startTime?: string;
       endTime?: string;
       duration?: number;

--- a/packages/ports/src/run-index-store/run-index-store.port.ts
+++ b/packages/ports/src/run-index-store/run-index-store.port.ts
@@ -1,40 +1,27 @@
-import type {
-  AnyEvent,
-  JobCompletedEvent,
-  JobFailedEvent,
-  JobSubmittedEvent,
-} from "@lcase/types";
+import type { AnyEvent } from "@lcase/types";
 
 export type RunIndex = {
   flowId: string;
   traceId: string;
-  flowDefHash: string;
+  flowDefHash?: string;
   forkSpecHash?: string;
   parentId?: string;
-  startTime: string;
-  endTime: string;
+  startTime?: string;
+  endTime?: string;
+  duration?: number;
   steps: Record<
     string,
     {
-      outputHash: string;
+      outputHash?: string;
       status: string;
-      startTime: string;
-      endTime: string;
+      startTime?: string;
+      endTime?: string;
+      duration?: number;
       argsHash?: string;
     }
   >;
 };
 
 export interface RunIndexStorePort {
-  addRunRequested(event: AnyEvent<"run.requested">): Promise<void>;
-  addJobSubmitted(event: JobSubmittedEvent): Promise<void>;
-  addJobFinished(event: JobCompletedEvent | JobFailedEvent): Promise<void>;
-  addRunStarted(event: AnyEvent<"run.started">): Promise<void>;
-  addRunFinished(
-    event: AnyEvent<"run.completed"> | AnyEvent<"run.failed">,
-  ): Promise<void>;
-  addStepStarted(event: AnyEvent<"step.started">): Promise<void>;
-  addStepFinished(
-    event: AnyEvent<"step.completed"> | AnyEvent<"step.failed">,
-  ): Promise<void>;
+  processEvent(event: AnyEvent): Promise<void>;
 }

--- a/packages/types/src/events/step/data.ts
+++ b/packages/types/src/events/step/data.ts
@@ -15,9 +15,11 @@ export type StepStartedData = StepDescriptor & {
 
 export type StepCompletedData = StepDescriptor & {
   status: "success";
+  outputHash?: string;
 };
 
 export type StepFailedData = StepDescriptor & {
   status: "failure";
+  outputHash?: string;
   reason: string;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,18 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)
 
+  packages/app-services/run-history:
+    devDependencies:
+      '@lcase/ports':
+        specifier: workspace:*
+        version: link:../../ports
+      '@lcase/types':
+        specifier: workspace:*
+        version: link:../../types
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)
+
   packages/artifacts:
     devDependencies:
       '@lcase/ports':
@@ -376,6 +388,9 @@ importers:
 
   packages/observability:
     dependencies:
+      '@lcase/run-history':
+        specifier: workspace:*
+        version: link:../app-services/run-history
       ws:
         specifier: ^8.18.3
         version: 8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       '@lcase/json-ref-binder':
         specifier: workspace:*
         version: link:../json-ref-binder
+      '@lcase/run-history':
+        specifier: workspace:*
+        version: link:../app-services/run-history
       '@lcase/specs':
         specifier: workspace:*
         version: link:../specs

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - packages/*
+  - packages/app-services/*
   - apps/*
   - examples/
 


### PR DESCRIPTION
## Summary

Implement a run indexer which writes metadata about a run to a file.  Also implement a reader that reads a run index to grab the output hash for a list of steps.

## Related Issues

- #186 

## Changes

- [x] Add `RunIndexStorePort` and `RunIndex` data schema type to `@lcase/ports` package.
- [x] Implement `FsRunIndexStore` class as adapter to `RunIndexStorePort`
- [x] Integrate `FsRunIndexStore` + `run-history` app-service inside event log observability sink.
- [x] Add tests for `FsRunIndexStore`
- [x] Add tests for `run-history` app-service functions.
- [x] Create a reader that uses the store interface to read metadata from the index.