### PR TITLE
feat(cli): add flow to CAS cmd

### DIFF
--- a/apps/cli/src/commands/add/add.cmd.ts
+++ b/apps/cli/src/commands/add/add.cmd.ts
@@ -1,0 +1,27 @@
+import type { ServicesPort } from "@lcase/ports";
+import { Command } from "commander";
+import { resolveCliPath } from "../../resolve-path.js";
+
+export async function cliAddAction(
+  services: ServicesPort,
+  pathToFlow: string,
+): Promise<void> {
+  console.log("[cli] add command");
+
+  const absolutePath = resolveCliPath(pathToFlow);
+  await services.system.startSystem();
+  await services.flow.storeFlowInCas(absolutePath);
+}
+
+export function registerAddCmd(
+  program: Command,
+  services: ServicesPort,
+): Command {
+  program
+    .command("add <pathToFlow>")
+    .description("replay a run without side effects")
+    .action(async (pathToFlow: string) => {
+      await cliAddAction(services, pathToFlow);
+    });
+  return program;
+}

--- a/apps/cli/src/commands/register-commands.ts
+++ b/apps/cli/src/commands/register-commands.ts
@@ -6,6 +6,7 @@ import { WorkflowController } from "@lcase/controller";
 import { registerReplayCmd } from "./replay/replay.cmd.js";
 import { registerSimCmd } from "./sim/sim.cmd.js";
 import { ServicesPort } from "@lcase/ports";
+import { registerAddCmd } from "./add/add.cmd.js";
 
 export function registerCommands(program: Command, services: ServicesPort) {
   registerRunCmd(program, services);
@@ -13,4 +14,5 @@ export function registerCommands(program: Command, services: ServicesPort) {
   registerValidateCmd(program, services);
   registerReplayCmd(program, services);
   registerSimCmd(program, services);
+  registerAddCmd(program, services);
 }

--- a/packages/observability/src/sinks/console.sink.ts
+++ b/packages/observability/src/sinks/console.sink.ts
@@ -1,6 +1,7 @@
 // stub for console.log output for observability
 
 import type { EventSink } from "@lcase/ports";
+import { hasRunId } from "@lcase/run-history";
 import { AnyEvent, EventType } from "@lcase/types";
 
 export type ConsoleSinkContext = {
@@ -41,6 +42,9 @@ export class ConsoleSink implements EventSink {
 
     let ok = "\x1b[38;2;108;235;106m[✔]\x1b[0m";
     if (event.action !== "completed") ok = "";
+    if (event.type === "run.completed" || event.type === "run.failed") {
+      if (hasRunId(event)) console.log(`runId: ${event.runid}`);
+    }
 
     let log = "";
     if (event.type === "system.logged") {
@@ -51,7 +55,7 @@ export class ConsoleSink implements EventSink {
       log = l.data.step.id + " | " + l.data.step.type;
     }
     console.log(
-      `${this.#c[event.domain]}[${event.type}]${this.#s}${ok} ${log}`
+      `${this.#c[event.domain]}[${event.type}]${this.#s}${ok} ${log}`,
     );
 
     if (this.ctx.allVerbose || this.ctx.verboseEvents.has(event.type)) {

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -23,6 +23,7 @@ export interface FlowServicePort {
   startFlow(args: { absoluteFilePath?: string }): Promise<void>;
   listFlows(args: { absoluteDirPath?: string }): Promise<FlowList>;
   validateJsonFlow(blob: unknown): FlowDefinition | string;
+  storeFlowInCas(path: string): Promise<void>;
 }
 export interface ReplayServicePort {
   replayRun(runId: string): Promise<void>;

--- a/packages/runtime/src/create-services.ts
+++ b/packages/runtime/src/create-services.ts
@@ -13,7 +13,12 @@ import { ServicesPort } from "@lcase/ports";
 export function createServices(config: RuntimeConfig): ServicesPort {
   const ctx = makeRuntimeContext(config);
 
-  const flow = new FlowService(ctx.bus, ctx.ef, new FlowStoreFs());
+  const flow = new FlowService(
+    ctx.bus,
+    ctx.ef,
+    new FlowStoreFs(),
+    ctx.artifacts,
+  );
   const replay = new ReplayService(ctx.replay);
   const sim = new SimService(ctx.artifacts, ctx.ef, ctx.runIndexStore);
   const run = new RunService(ctx.ef);

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -52,7 +52,12 @@ export function createRuntime(config: RuntimeConfig): WorkflowRuntime {
 
   const ef = new EmitterFactory(ctx.bus);
 
-  const flowService = new FlowService(ctx.bus, ef, new FlowStoreFs());
+  const flowService = new FlowService(
+    ctx.bus,
+    ef,
+    new FlowStoreFs(),
+    ctx.artifacts,
+  );
   const replayService = new ReplayService(ctx.replay);
   const simService = new SimService(ctx.artifacts, ctx.ef, ctx.runIndexStore);
 

--- a/packages/use-cases/run-flow/src/add-flow.ts
+++ b/packages/use-cases/run-flow/src/add-flow.ts
@@ -1,0 +1,34 @@
+import type { ArtifactsPort, JsonValue } from "@lcase/ports";
+import type { FlowDefinition } from "@lcase/types";
+import path from "node:path";
+import fs from "node:fs";
+
+export async function addFlowToCas(
+  flowDef: FlowDefinition,
+  artifacts: ArtifactsPort,
+): Promise<string | undefined> {
+  try {
+    const result = await artifacts.putJson(flowDef as JsonValue);
+    if (result.ok) return result.value;
+    console.log(`Unable to save flow in CAS: ${result.error}`);
+  } catch (e) {
+    throw new Error(`Error adding file to CAS: ${e}`);
+  }
+}
+
+export function readFlowFile(absoluteFilePath: string): JsonValue {
+  if (
+    !path.isAbsolute(absoluteFilePath) ||
+    path.extname(absoluteFilePath).length === 0
+  ) {
+    throw new Error(`Path is not an absolute file path: ${absoluteFilePath}`);
+  }
+
+  try {
+    const data = fs.readFileSync(absoluteFilePath, { encoding: "utf8" });
+    const json = JSON.parse(data) as JsonValue;
+    return json;
+  } catch (e) {
+    throw new Error(`Error adding file to CAS: ${e}`);
+  }
+}

--- a/packages/use-cases/run-flow/src/index.ts
+++ b/packages/use-cases/run-flow/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./create-fork-spec.js";
 export * from "./run-flow.js";
+export * from "./add-flow.js";


### PR DESCRIPTION
## Summary

Add a quick way to add flows to content addressable storage and display the hash in the console.  Useful for using the new `run` command which works off of CAS hashes currently

Invoke command with `add <pathToFlow>`.

## Changes

- [x] Updates `FlowService` to implement a pipeline to add a flow to CAS and print out the hash.
- [X] Add appropriate use case functions to perform business operations.

## Notes

This code is currently untested aside from some happy path smoke tests.  Its added as a convenience to easily go from flow definition on disk to running with the new CAS system, without implementing a full flow manager.  Flow management is a broader topic that should be addressed along with the coming HTTP server and React UI.