### PR TITLE
feat: add get flow list endpoint to server + web ui

### DIFF
--- a/apps/http-server/src/routes/flows/add.ts
+++ b/apps/http-server/src/routes/flows/add.ts
@@ -4,7 +4,7 @@ import type { FastifyInstance } from "fastify/types/instance.js";
 export const postFlowsRoute = async (app: FastifyInstance) => {
   app.post<{ Body: FlowDefinition }>("/", async (req, reply) => {
     const flowDef = req.body;
-    const result = await app.services.flow.addJsonFlow(flowDef);
+    const result = await app.services.flow.addFlow(flowDef);
     if (!result.ok) return { ...result };
     return { ...result };
   });

--- a/apps/http-server/src/routes/flows/files/post.ts
+++ b/apps/http-server/src/routes/flows/files/post.ts
@@ -21,7 +21,7 @@ export const postFlowsFilesRoute = async (app: FastifyInstance) => {
 
         const buffer = await part.toBuffer();
         const text = buffer.toString("utf8");
-        const result = await app.services.flow.addJsonFlow(text);
+        const result = await app.services.flow.addFlow(text);
 
         if (result.ok === false) return reply.code(500).send(result);
         return result;

--- a/apps/http-server/src/routes/flows/get.ts
+++ b/apps/http-server/src/routes/flows/get.ts
@@ -1,0 +1,10 @@
+import type { FastifyInstance } from "fastify";
+
+export const listFlowsRoute = async (app: FastifyInstance) => {
+  app.get("/", async (req, reply) => {
+    const result = await app.services.flow.getAllFlowIndexes();
+
+    if (result.ok) return { ok: result.ok, indexes: result.value };
+    return reply.send(result);
+  });
+};

--- a/apps/http-server/src/routes/flows/list.ts
+++ b/apps/http-server/src/routes/flows/list.ts
@@ -1,7 +1,0 @@
-import type { FastifyInstance } from "fastify";
-
-export const listFlowsRoute = async (app: FastifyInstance) => {
-  app.get("/", async (req, reply) => {
-    reply.send({ ok: true });
-  });
-};

--- a/apps/http-server/src/routes/routes.ts
+++ b/apps/http-server/src/routes/routes.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyPluginAsync } from "fastify";
-import { listFlowsRoute } from "./flows/list.js";
+import { listFlowsRoute } from "./flows/get.js";
 import { postFlowsRoute } from "./flows/add.js";
 import { listRunsRoute } from "./runs/list.js";
 import { postFlowsFilesRoute } from "./flows/files/post.js";

--- a/apps/web-app/src/components/AddJsonFlow.tsx
+++ b/apps/web-app/src/components/AddJsonFlow.tsx
@@ -47,14 +47,15 @@ export function AddJsonFlow() {
   };
 
   return (
-    <>
-      <p className="mt-5">Json Flow Definition</p>
+    <div>
+      <p className="mt-8 text-md font-bold">Upload JSON Directly</p>
+      <hr className="text-sky-600 text-o mb-6"></hr>
       <textarea
         value={json}
         onChange={(e) => handleChange(e.target.value)}
         id="add-json-flow"
         className="w-6/6 min-h-[500px] resize-none bg-blue-100
-          dark:bg-slate-800 dark:border-slate-600 dark:border-2 dark:text-amber-200
+          dark:bg-slate-800 dark:border-slate-800 dark:text-amber-200
 
         rounded-md text-black p-4 mt-2 font-mono text-sm/4"
       ></textarea>
@@ -69,6 +70,6 @@ export function AddJsonFlow() {
             : ""}
         </span>
       </p>
-    </>
+    </div>
   );
 }

--- a/apps/web-app/src/components/FlowListItem.tsx
+++ b/apps/web-app/src/components/FlowListItem.tsx
@@ -1,0 +1,17 @@
+import type { FlowIndex } from "@lcase/types";
+
+export function FlowListItem({ index }: { index: FlowIndex }) {
+  return (
+    <div className="mb-5">
+      <p>
+        <span className="font-bold text-sm">{index.name}</span>
+        <span className="text-sm ml-3 text-slate-300">{index.version}</span>
+      </p>
+      {index.description ? (
+        <p className="text-sm text-slate-300">{index.description}</p>
+      ) : (
+        ""
+      )}
+    </div>
+  );
+}

--- a/apps/web-app/src/components/ListFlows.tsx
+++ b/apps/web-app/src/components/ListFlows.tsx
@@ -1,0 +1,21 @@
+import { useGetFlowsQuery } from "../redux/api/flows-api";
+import { FlowListItem } from "./FlowListItem";
+
+export function ListFlows() {
+  const { data, error, isLoading } = useGetFlowsQuery();
+
+  if (isLoading) return <div>Loading Flow List...</div>;
+  if (data?.ok === false)
+    return <div>Error loading Flow List:{JSON.stringify(data.error)}</div>;
+  if (error || !data) return <div>Error loading Flow List</div>;
+
+  return (
+    <div className="mt-4">
+      <h3 className="text-lg font-bold">Flow List</h3>
+      <hr className="text-sky-600 text-o mb-6"></hr>
+      {data.indexes.map((index) => (
+        <FlowListItem key={index.hash} index={index} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web-app/src/components/UploadFlowFile.tsx
+++ b/apps/web-app/src/components/UploadFlowFile.tsx
@@ -28,15 +28,17 @@ export function UploadFlowFile() {
     }
   };
   return (
-    <form onSubmit={handleSubmit}>
-      <h3>Upload JSON Flow File</h3>
-      <label>
-        File:
-        <input
-          type="file"
-          accept=".json,application/json,text/json"
-          onChange={onSelectFile}
-          className="bg-sky-800 cursor-pointer rounded-md
+    <div className="mt-8">
+      <form onSubmit={handleSubmit}>
+        <h3 className="font-bold">Upload JSON Flow File</h3>
+        <hr className="text-sky-600 text-o mb-5"></hr>
+        <label>
+          File:
+          <input
+            type="file"
+            accept=".json,application/json,text/json"
+            onChange={onSelectFile}
+            className="bg-sky-800 cursor-pointer rounded-md
             ml-2
             mr-2
             pl-2
@@ -44,15 +46,16 @@ export function UploadFlowFile() {
             text-md
             transition duration-300 ease-in-out hover:translate
            hover:inset-ring hover:inset-ring-sky-500"
-        />
-      </label>
-      <button
-        type="submit"
-        disabled={uploadState.isLoading || files.length === 0}
-      >
-        {uploadState.isLoading ? "Uploading... " : "Upload"}
-      </button>
-      <p>Status: {uploadRes.toString()}</p>
-    </form>
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={uploadState.isLoading || files.length === 0}
+        >
+          {uploadState.isLoading ? "Uploading... " : "Upload"}
+        </button>
+        <p>Status: {uploadRes.toString()}</p>
+      </form>
+    </div>
   );
 }

--- a/apps/web-app/src/pages/Flows.tsx
+++ b/apps/web-app/src/pages/Flows.tsx
@@ -1,4 +1,5 @@
 import { AddJsonFlow } from "../components/AddJsonFlow";
+import { ListFlows } from "../components/ListFlows";
 import { UploadFlowFile } from "../components/UploadFlowFile";
 import { Header } from "../layout/Header";
 import { Main } from "../layout/Main";
@@ -8,7 +9,8 @@ export function Flows() {
     <div id="page-wrapper">
       <Header />
       <Main>
-        <h2 className="text-lg font-bold">Flows</h2>
+        <h2 className="text-xl font-bold mb-5">Flows</h2>
+        <ListFlows />
         <UploadFlowFile />
         <AddJsonFlow />
       </Main>

--- a/apps/web-app/src/redux/api/flows-api.ts
+++ b/apps/web-app/src/redux/api/flows-api.ts
@@ -1,4 +1,5 @@
 import type {
+  GetFlowsRes,
   PostFlowFileRes,
   PostJsonFlowReq,
   PostJsonFlowRes,
@@ -9,11 +10,15 @@ export const flowsApi = createApi({
   reducerPath: "flowsApi",
   baseQuery: fetchBaseQuery({ baseUrl: "http://localhost:3000/api/" }),
   endpoints: (builder) => ({
+    getFlows: builder.query<GetFlowsRes, void>({
+      query: () => "flows",
+    }),
     addJsonFlow: builder.mutation<PostJsonFlowRes, PostJsonFlowReq>({
       query: (arg) => ({
         url: "flows",
         method: "POST",
         body: arg.body,
+        headers: { "Content-Type": "application/json" },
       }),
     }),
     uploadFlowFile: builder.mutation<PostFlowFileRes, { files: File[] }>({
@@ -31,4 +36,8 @@ export const flowsApi = createApi({
   }),
 });
 
-export const { useAddJsonFlowMutation, useUploadFlowFileMutation } = flowsApi;
+export const {
+  useAddJsonFlowMutation,
+  useUploadFlowFileMutation,
+  useGetFlowsQuery,
+} = flowsApi;

--- a/packages/adapters/src/flow-index-store/flow-index-store.ts
+++ b/packages/adapters/src/flow-index-store/flow-index-store.ts
@@ -20,7 +20,6 @@ export class FsFlowIndexStore implements FlowIndexStorePort {
       fs.writeFileSync(fullPath, json, { encoding: "utf8" });
       return { ok: true, value: fullPath };
     } catch (e) {
-      console.log("Error writing run index", e);
       return { ok: false, error: `Error writing run index: ${e}` };
     }
   }
@@ -49,6 +48,9 @@ export class FsFlowIndexStore implements FlowIndexStorePort {
         const json = await JSON.parse(data);
         indexes.push(json as FlowIndex);
       }
+      indexes.sort((a, b) =>
+        a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1,
+      );
       return { ok: true, value: indexes };
     } catch (e) {
       return { ok: false, error: `Error getting all indexes: ${e}` };

--- a/packages/adapters/tests/flow-index-store/fs-flow-index-store.test.ts
+++ b/packages/adapters/tests/flow-index-store/fs-flow-index-store.test.ts
@@ -23,7 +23,7 @@ describe("FsFlowIndexStore", () => {
     const json = await JSON.parse(data);
     expect(json).toEqual(index);
   });
-  it("putFlowIndex() reads the expected index", async () => {
+  it("getFlowIndex() reads the expected index", async () => {
     const dirPath = path.resolve(
       import.meta.dirname,
       "../fixtures/flow-index-store",

--- a/packages/ports/src/flow-index-store/flow-index-store.ts
+++ b/packages/ports/src/flow-index-store/flow-index-store.ts
@@ -3,4 +3,5 @@ import type { FlowIndex, Result } from "@lcase/types";
 export interface FlowIndexStorePort {
   putFlowIndex(index: FlowIndex): Promise<Result<string, string>>;
   getFlowIndex(hash: string): Promise<Result<FlowIndex, string>>;
+  getAllFlowIndexes(): Promise<Result<FlowIndex[], string>>;
 }

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -25,6 +25,7 @@ export interface FlowServicePort {
   validateJsonFlow(blob: unknown): FlowDefinition | string;
   storeFlowInCas(path: string): Promise<void>;
   addJsonFlow(json: unknown): Promise<Result<FlowIndex, string>>;
+  getAllFlowIndexes(): Promise<Result<FlowIndex[], string>>;
 }
 export interface ReplayServicePort {
   replayRun(runId: string): Promise<void>;

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -22,9 +22,11 @@ export interface SimServicePort {
 export interface FlowServicePort {
   startFlow(args: { absoluteFilePath?: string }): Promise<void>;
   listFlows(args: { absoluteDirPath?: string }): Promise<FlowList>;
-  validateJsonFlow(blob: unknown): FlowDefinition | string;
+  validateJsonFlow(
+    flow: string | Record<string, unknown>,
+  ): FlowDefinition | string;
   storeFlowInCas(path: string): Promise<void>;
-  addJsonFlow(json: unknown): Promise<Result<FlowIndex, string>>;
+  addFlow(flow: string | FlowDefinition): Promise<Result<FlowIndex, string>>;
   getAllFlowIndexes(): Promise<Result<FlowIndex[], string>>;
 }
 export interface ReplayServicePort {

--- a/packages/services/src/flow.service.ts
+++ b/packages/services/src/flow.service.ts
@@ -94,6 +94,10 @@ export class FlowService implements FlowServicePort {
     return flowList;
   }
 
+  async getAllFlowIndexes(): Promise<Result<FlowIndex[], string>> {
+    return await this.flowIndexStore.getAllFlowIndexes();
+  }
+
   validateJsonFlow(blob: unknown): FlowDefinition | string {
     if (blob === undefined) return "Invalid flow: Undefined";
     try {

--- a/packages/services/src/flow.service.ts
+++ b/packages/services/src/flow.service.ts
@@ -76,7 +76,7 @@ export class FlowService implements FlowServicePort {
     };
 
     for (const [absolutePath, blob] of flows.entries()) {
-      const flow = this.validateJsonFlow(blob);
+      const flow = this.validateJsonFlow(blob as string);
       if (typeof flow === "string") {
         flowList.invalidFlows[absolutePath] = { errorMessage: flow };
       } else {
@@ -98,11 +98,13 @@ export class FlowService implements FlowServicePort {
     return await this.flowIndexStore.getAllFlowIndexes();
   }
 
-  validateJsonFlow(blob: unknown): FlowDefinition | string {
-    if (blob === undefined) return "Invalid flow: Undefined";
+  validateJsonFlow(
+    flow: string | Record<string, unknown>,
+  ): FlowDefinition | string {
+    if (flow === undefined) return "Invalid flow: Undefined";
     try {
-      const flow = JSON.parse(blob as string);
-      const result = FlowSchema.safeParse(flow);
+      const flowObject = typeof flow === "string" ? JSON.parse(flow) : flow;
+      const result = FlowSchema.safeParse(flowObject);
       if (!result.success) {
         return JSON.stringify(result.error, null, 2);
       }
@@ -128,10 +130,12 @@ export class FlowService implements FlowServicePort {
     }
   }
 
-  async addJsonFlow(json: unknown): Promise<Result<FlowIndex, string>> {
+  async addFlow(
+    flow: string | Record<string, unknown>,
+  ): Promise<Result<FlowIndex, string>> {
     // const parseResult = parseFlow(json);
 
-    const validateResult = this.validateJsonFlow(json);
+    const validateResult = this.validateJsonFlow(flow);
     if (typeof validateResult === "string") {
       return { ok: false, error: validateResult };
     }

--- a/packages/types/src/api/flows/get-flows-json.ts
+++ b/packages/types/src/api/flows/get-flows-json.ts
@@ -1,5 +1,5 @@
 import type { FlowIndex } from "../../flow-index-store/flow-index.js";
 
 export type GetFlowsRes =
-  | { ok: true; indexes: FlowIndex }
+  | { ok: true; indexes: FlowIndex[] }
   | { ok: false; error: string };

--- a/packages/types/src/api/flows/get-flows-json.ts
+++ b/packages/types/src/api/flows/get-flows-json.ts
@@ -1,0 +1,5 @@
+import type { FlowIndex } from "../../flow-index-store/flow-index.js";
+
+export type GetFlowsRes =
+  | { ok: true; indexes: FlowIndex }
+  | { ok: false; error: string };

--- a/packages/types/src/api/index.ts
+++ b/packages/types/src/api/index.ts
@@ -1,2 +1,3 @@
 export * from "./flows/post-flow-json.js";
+export * from "./flows/get-flows-json.js";
 export * from "./flows/files/post-flow-file.js";


### PR DESCRIPTION
## Summary

Add an endpoint `api/flows` that returns an array of `FlowIndex` objects, and display those flows in the web app ui.

## Related Issues

- #197 

## Changes

- [x] Add endpoint that returns `FlowIndex` array.
- [x] Display http server response in web app ui.