### PR TITLE
feat: add react flow view for flows

### DIFF
--- a/apps/http-server/src/routes/flows/get-flow-def.ts
+++ b/apps/http-server/src/routes/flows/get-flow-def.ts
@@ -1,0 +1,26 @@
+import type { FastifyInstance } from "fastify";
+
+export const getFlowDefRoute = async (app: FastifyInstance) => {
+  app.get<{ Params: { flowId: unknown } }>("/:flowId", async (req, reply) => {
+    const { flowId } = req.params;
+    if (!isFlowId(flowId)) {
+      return { ok: false, error: "Invalid flow id format" };
+    }
+
+    const result = await app.services.flow.getFlowDef(flowId);
+    return result;
+  });
+};
+
+/**
+ * Narrows the type of flow id if is a valid flow id string
+ * @param flowId unknown
+ * @returns
+ */
+export function isFlowId(flowId: unknown): flowId is string {
+  if (typeof flowId !== "string") return false;
+  const regex = /^[a-zA-Z0-9]+$/;
+  const match = flowId.match(regex);
+  if (!match) return false;
+  return true;
+}

--- a/apps/http-server/src/routes/routes.ts
+++ b/apps/http-server/src/routes/routes.ts
@@ -3,9 +3,11 @@ import { listFlowsRoute } from "./flows/get.js";
 import { postFlowsRoute } from "./flows/add.js";
 import { listRunsRoute } from "./runs/list.js";
 import { postFlowsFilesRoute } from "./flows/files/post.js";
+import { getFlowDefRoute } from "./flows/get-flow-def.js";
 
 export const routes: FastifyPluginAsync = async (app: FastifyInstance) => {
   await app.register(listFlowsRoute, { prefix: "/api/flows" });
+  await app.register(getFlowDefRoute, { prefix: "/api/flows" });
   await app.register(postFlowsRoute, { prefix: "/api/flows" });
   await app.register(postFlowsFilesRoute, { prefix: "/api/flows/files" });
   await app.register(listRunsRoute, { prefix: "/api/runs" });

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "1.1.8",
     "@lcase/flow-analysis": "workspace:*",
     "@lcase/specs": "workspace:*",
     "@reduxjs/toolkit": "^2.11.2",

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -15,6 +15,7 @@
     "@lcase/specs": "workspace:*",
     "@reduxjs/toolkit": "^2.11.2",
     "@tailwindcss/vite": "^4.1.17",
+    "@xyflow/react": "^12.10.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-redux": "^9.2.0",

--- a/apps/web-app/src/App.tsx
+++ b/apps/web-app/src/App.tsx
@@ -2,12 +2,14 @@ import "./App.css";
 import { Route, Routes } from "react-router-dom";
 import { Dashboard } from "./pages/Dashboard";
 import { Flows } from "./pages/Flows";
+import { FlowsEdit } from "./pages/FlowsEdit";
 
 export function App() {
   return (
     <Routes>
       <Route path="/" element={<Dashboard />} />
       <Route path="/flows" element={<Flows />} />
+      <Route path="/flows/edit/:flowId" element={<FlowsEdit />} />
       {/* <Route path="/sims" element={<Sims />} />
       <Route path="/runs" element={<Runs />} />
       <Route path="/system" element={<System />} />

--- a/apps/web-app/src/components/FlowEditPanel.tsx
+++ b/apps/web-app/src/components/FlowEditPanel.tsx
@@ -1,0 +1,67 @@
+import { useParams } from "react-router-dom";
+import { useGetFlowDefQuery } from "../redux/api/flows-api";
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useMemo } from "react";
+import { analyzeFlow, graphLayout, toposort } from "@lcase/flow-analysis";
+import { Controls, ReactFlow, type Edge, type Node } from "@xyflow/react";
+
+import "@xyflow/react/dist/base.css";
+
+function calcPosition(row: number, nodes: number, distance: number) {
+  const offsetAmount = Math.floor(nodes / 2);
+  const offsetRow = row - offsetAmount;
+  return offsetRow * distance;
+}
+
+export function FlowEditPanel() {
+  const { flowId } = useParams<{ flowId: string }>();
+  const { data } = useGetFlowDefQuery(flowId ?? skipToken);
+
+  const result = useMemo(() => {
+    if (!data || data.ok === false) return;
+    const fa = analyzeFlow(data.value);
+    fa.toposort = toposort(fa);
+    const layout = graphLayout(fa);
+    if (!layout) return { nodes: [], edges: [] };
+
+    const newNodes: Node[] = [];
+    const newEdges: Edge[] = [];
+
+    for (let row = 0; row < layout.length; row++) {
+      for (let col = 0; col < layout[row].length; col++) {
+        const node = layout[row][col];
+        const x = calcPosition(col, layout[row].length, 250);
+
+        const newNode: Node = {
+          id: node,
+          position: { x, y: 150 * row },
+          data: { label: `${node}: ${data.value.steps[node]?.type}` },
+        };
+        newNodes.push(newNode);
+
+        if (fa.outEdges[node]) {
+          for (const edge of fa.outEdges[node]) {
+            const newEdge: Edge = {
+              id: `${edge.startStepId}-${edge.endStepId}`,
+              source: edge.startStepId,
+              target: edge.endStepId,
+              label: edge.gate,
+            };
+            newEdges.push(newEdge);
+          }
+        }
+      }
+    }
+    return { nodes: newNodes, edges: newEdges };
+  }, [data]);
+
+  if (!result) return <div>no nodes or edges</div>;
+
+  return (
+    <div className="w-[800px] h-[800px] rounded-xl text-sm  bg-slate-800 color-white text-slate-200 ">
+      <ReactFlow nodes={result.nodes} edges={result.edges} fitView>
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/web-app/src/components/FlowListItem.tsx
+++ b/apps/web-app/src/components/FlowListItem.tsx
@@ -1,10 +1,13 @@
 import type { FlowIndex } from "@lcase/types";
+import { Link } from "react-router-dom";
 
 export function FlowListItem({ index }: { index: FlowIndex }) {
   return (
     <div className="mb-5">
       <p>
-        <span className="font-bold text-sm">{index.name}</span>
+        <span className="font-bold text-sm">
+          <Link to={`/flows/edit/${index.hash}`}>{index.name}</Link>
+        </span>
         <span className="text-sm ml-3 text-slate-300">{index.version}</span>
       </p>
       {index.description ? (

--- a/apps/web-app/src/components/FlowTree.tsx
+++ b/apps/web-app/src/components/FlowTree.tsx
@@ -1,0 +1,85 @@
+import type { FlowDefinition } from "@lcase/types";
+import { analyzeFlow } from "@lcase/flow-analysis";
+import {
+  applyEdgeChanges,
+  applyNodeChanges,
+  Background,
+  Controls,
+  ReactFlow,
+  type Edge,
+  type EdgeChange,
+  type Node,
+  type NodeChange,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useCallback, useState } from "react";
+
+const initialNodes = [
+  { id: "n1", position: { x: 0, y: 0 }, data: { label: "Node 1" } },
+  { id: "n2", position: { x: 0, y: 100 }, data: { label: "Node 2" } },
+];
+const initialEdges = [{ id: "n1-n2", source: "n1", target: "n2" }];
+export function FlowTree({ flowDef }: { flowDef: FlowDefinition }) {
+  const [nodes, setNodes] = useState<Node[]>(initialNodes);
+  const [edges, setEdges] = useState<Edge[]>(initialEdges);
+
+  const handleReload = () => {
+    const fa = analyzeFlow(flowDef);
+    const newNodes: Node[] = [];
+    const newEdges: Edge[] = [];
+    let count = 0;
+    for (const node of fa.nodes) {
+      const newNode: Node = {
+        id: node,
+        position: { x: 0, y: 100 * count },
+        data: { label: `${node}: ${flowDef.steps[node]?.type}` },
+      };
+      newNodes.push(newNode);
+
+      if (fa.outEdges[node]) {
+        console.log("edges");
+        for (const edge of fa.outEdges[node]) {
+          const newEdge: Edge = {
+            id: `${edge.startStepId}-${edge.endStepId}`,
+            source: edge.startStepId,
+            target: edge.endStepId,
+            label: edge.gate,
+          };
+          newEdges.push(newEdge);
+        }
+      }
+      count++;
+    }
+
+    setNodes(newNodes);
+    setEdges(newEdges);
+  };
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) =>
+      setNodes((nodesSnapshot) => applyNodeChanges(changes, nodesSnapshot)),
+    [],
+  );
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) =>
+      setEdges((edgesSnapshot) => applyEdgeChanges(changes, edgesSnapshot)),
+    [],
+  );
+
+  return (
+    <div className="w-[500px] h-[500px] rounded-xl bg-slate-800 text-slate-900">
+      <h3>Flow Tree</h3>
+      <button onClick={handleReload}>Reload</button>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        fitView
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+      >
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/web-app/src/index.css
+++ b/apps/web-app/src/index.css
@@ -1,3 +1,4 @@
+@import "@xyflow/react/dist/style.css";
 @import "tailwindcss";
 
 @theme {
@@ -20,6 +21,45 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   padding-top: 0px;
+}
+.react-flow__node,
+.react-flow__node-default {
+  background-color: #34516e;
+  border-bottom-color: #53f2d0;
+  border: none !important;
+}
+.react-flow__edge-textbg {
+  fill: #6e5934;
+  margin: 2rem;
+}
+.react-flow__edge-text {
+  fill: #eeeeee;
+}
+.react-flow {
+  background-color: #53f2d0;
+}
+.react-flow__controls-button {
+  background-color: #34516e;
+  border: 0;
+  margin-top: 0.5rem;
+}
+.react-flow__controls-button:hover {
+  background-color: #5481ae;
+  border: 0;
+  margin-top: 0.5rem;
+}
+.react-flow__attribution a {
+  background-color: #34516e;
+  border: 0;
+
+  color: #eeeeee !important;
+}
+
+.react-flow__attribution {
+  background: #34516e;
+  background-color: #34516e !important;
+  color: #ffffff !important;
+  border: 0;
 }
 
 html {

--- a/apps/web-app/src/pages/Flows.tsx
+++ b/apps/web-app/src/pages/Flows.tsx
@@ -1,60 +1,8 @@
-import type { FlowDefinition } from "@lcase/types";
 import { AddJsonFlow } from "../components/AddJsonFlow";
-import { FlowTree } from "../components/FlowTree";
 import { ListFlows } from "../components/ListFlows";
 import { UploadFlowFile } from "../components/UploadFlowFile";
 import { Header } from "../layout/Header";
 import { Main } from "../layout/Main";
-
-const flow: FlowDefinition = {
-  name: "Parallel Flow Test",
-  version: "0.1.0-alpha.9",
-  start: "p",
-  steps: {
-    p: {
-      type: "parallel",
-      steps: ["one", "two", "three"],
-    },
-    one: {
-      type: "httpjson",
-      url: "https://swapi.tech/api/people/1",
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
-    two: {
-      type: "httpjson",
-      url: "https://swapi.tech/api/people/2",
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
-    three: {
-      type: "httpjson",
-      url: "https://swapi.tech/api/people/3",
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
-    "join-step": {
-      type: "join",
-      steps: ["two", "one"],
-      next: "five",
-    },
-
-    five: {
-      type: "httpjson",
-      url: "{{steps.two.output.body.result.properties.homeworld}}",
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
-  },
-};
 
 export function Flows() {
   return (
@@ -63,7 +11,6 @@ export function Flows() {
       <Main>
         <h2 className="text-xl font-bold mb-5">Flows</h2>
         <ListFlows />
-        <FlowTree flowDef={flow} />
         <UploadFlowFile />
         <AddJsonFlow />
       </Main>

--- a/apps/web-app/src/pages/Flows.tsx
+++ b/apps/web-app/src/pages/Flows.tsx
@@ -1,8 +1,60 @@
+import type { FlowDefinition } from "@lcase/types";
 import { AddJsonFlow } from "../components/AddJsonFlow";
+import { FlowTree } from "../components/FlowTree";
 import { ListFlows } from "../components/ListFlows";
 import { UploadFlowFile } from "../components/UploadFlowFile";
 import { Header } from "../layout/Header";
 import { Main } from "../layout/Main";
+
+const flow: FlowDefinition = {
+  name: "Parallel Flow Test",
+  version: "0.1.0-alpha.9",
+  start: "p",
+  steps: {
+    p: {
+      type: "parallel",
+      steps: ["one", "two", "three"],
+    },
+    one: {
+      type: "httpjson",
+      url: "https://swapi.tech/api/people/1",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+    two: {
+      type: "httpjson",
+      url: "https://swapi.tech/api/people/2",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+    three: {
+      type: "httpjson",
+      url: "https://swapi.tech/api/people/3",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+    "join-step": {
+      type: "join",
+      steps: ["two", "one"],
+      next: "five",
+    },
+
+    five: {
+      type: "httpjson",
+      url: "{{steps.two.output.body.result.properties.homeworld}}",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  },
+};
 
 export function Flows() {
   return (
@@ -11,6 +63,7 @@ export function Flows() {
       <Main>
         <h2 className="text-xl font-bold mb-5">Flows</h2>
         <ListFlows />
+        <FlowTree flowDef={flow} />
         <UploadFlowFile />
         <AddJsonFlow />
       </Main>

--- a/apps/web-app/src/pages/FlowsEdit.tsx
+++ b/apps/web-app/src/pages/FlowsEdit.tsx
@@ -1,0 +1,21 @@
+import { Header } from "../layout/Header";
+import { Main } from "../layout/Main";
+
+import { FlowEditPanel } from "../components/FlowEditPanel";
+import { Link } from "react-router-dom";
+
+export function FlowsEdit() {
+  return (
+    <div id="page-wrapper">
+      <Header />
+      <Main>
+        <h2 className="text-xl font-bold mb-5">Flow Editor</h2>
+        <p className="text-sm mb-3">
+          <Link to="/flows">flows</Link> / edit
+        </p>
+
+        <FlowEditPanel />
+      </Main>
+    </div>
+  );
+}

--- a/apps/web-app/src/redux/api/flows-api.ts
+++ b/apps/web-app/src/redux/api/flows-api.ts
@@ -1,8 +1,10 @@
 import type {
+  FlowDefinition,
   GetFlowsRes,
   PostFlowFileRes,
   PostJsonFlowReq,
   PostJsonFlowRes,
+  Result,
 } from "@lcase/types";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
@@ -12,6 +14,9 @@ export const flowsApi = createApi({
   endpoints: (builder) => ({
     getFlows: builder.query<GetFlowsRes, void>({
       query: () => "flows",
+    }),
+    getFlowDef: builder.query<Result<FlowDefinition, string>, string>({
+      query: (flowId: string) => `/flows/${flowId}`,
     }),
     addJsonFlow: builder.mutation<PostJsonFlowRes, PostJsonFlowReq>({
       query: (arg) => ({
@@ -40,4 +45,5 @@ export const {
   useAddJsonFlowMutation,
   useUploadFlowFileMutation,
   useGetFlowsQuery,
+  useGetFlowDefQuery,
 } = flowsApi;

--- a/packages/flow-analysis/src/graph-layout.ts
+++ b/packages/flow-analysis/src/graph-layout.ts
@@ -1,0 +1,67 @@
+import { FlowAnalysis } from "@lcase/types";
+
+export function graphLayout(fa: FlowAnalysis) {
+  if (!fa.toposort) return;
+
+  const nodeRowMap = new Map<string, number>();
+  const pendingNodes = new Set<string>();
+  const grid: string[][] = [[]];
+
+  for (const node of fa.toposort) {
+    if (fa.inEdges[node] === undefined) {
+      grid[0].push(node);
+      nodeRowMap.set(node, 0);
+      const outTargetNodes = getOutTargetNodes(node, fa);
+      addToPending(outTargetNodes, pendingNodes);
+    } else {
+      break;
+    }
+  }
+
+  let currentRow = 1;
+  while (nodeRowMap.size < fa.toposort.length) {
+    for (const node of pendingNodes) {
+      if (inEdgesPlaced(node, currentRow, nodeRowMap, fa)) {
+        nodeRowMap.set(node, currentRow);
+        const outTargetNodes = getOutTargetNodes(node, fa);
+        addToPending(outTargetNodes, pendingNodes);
+        pendingNodes.delete(node);
+
+        (grid[currentRow] ??= []).push(node);
+      } else {
+      }
+    }
+    currentRow++;
+    if (currentRow > 200) break; // just a safety value to stop things going forever while in alpha
+  }
+  return grid;
+}
+
+export function getOutTargetNodes(node: string, fa: FlowAnalysis): string[] {
+  const outTargetNodes: string[] = [];
+  if (fa.outEdges[node]?.length > 0) {
+    for (const edge of fa.outEdges[node]) {
+      outTargetNodes.push(edge.endStepId);
+    }
+  }
+  return outTargetNodes;
+}
+
+export function addToPending(nodes: string[], pending: Set<string>) {
+  for (const node of nodes) {
+    pending.add(node);
+  }
+}
+
+export function inEdgesPlaced(
+  node: string,
+  row: number,
+  nodeRowMap: Map<string, number>,
+  fa: FlowAnalysis,
+) {
+  for (const edge of fa.inEdges[node]) {
+    const startStepNodeRow = nodeRowMap.get(edge.startStepId);
+    if (row === startStepNodeRow) return false;
+  }
+  return true;
+}

--- a/packages/flow-analysis/src/index.ts
+++ b/packages/flow-analysis/src/index.ts
@@ -2,3 +2,5 @@ export * from "./analyze-flow.js";
 export * from "./parse-references.js";
 export * from "./traverse.js";
 export * from "./analyze-references.js";
+export * from "./graph-layout.js";
+export * from "./toposort.js";

--- a/packages/flow-analysis/src/toposort.ts
+++ b/packages/flow-analysis/src/toposort.ts
@@ -1,0 +1,38 @@
+import { FlowAnalysis } from "@lcase/types";
+/**
+ * Uses a flow analysis to generate a toposort array of node ids.
+ * @param fa FlowAnalysis object
+ * @returns string[] of node ids
+ */
+export function toposort(fa: FlowAnalysis): string[] {
+  const inDegreeMap = new Map<string, number>();
+
+  const queue: string[] = [];
+  for (const node of fa.nodes) {
+    const inDegree = fa.inEdges[node]?.length ?? 0;
+    inDegreeMap.set(node, inDegree);
+    if (inDegree === 0) queue.push(node);
+  }
+
+  const toposort: string[] = [];
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    toposort.push(node);
+
+    if (fa.outEdges[node] === undefined) continue;
+
+    for (const edge of fa.outEdges[node]) {
+      console.log(edge);
+      const currentInEdges = inDegreeMap.get(edge.endStepId)!;
+      const remainingInEdges = currentInEdges - 1;
+      inDegreeMap.set(edge.endStepId, remainingInEdges);
+      if (remainingInEdges === 0) queue.push(edge.endStepId);
+    }
+  }
+
+  if (toposort.length !== fa.nodes.length) {
+    throw new Error("Cycle detected");
+  }
+  return toposort;
+}

--- a/packages/flow-analysis/tests/graph-layout.test.ts
+++ b/packages/flow-analysis/tests/graph-layout.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { analyzeFlow } from "../src/analyze-flow.js";
+import { graphLayout } from "../src/graph-layout.js";
+import type {
+  FlowAnalysis,
+  FlowDefinition,
+  StepHttpJson,
+  StepJoin,
+  StepParallel,
+} from "@lcase/types";
+
+describe("graphLayout()", () => {
+  it("creates a correct toposort", () => {
+    const fa: FlowAnalysis = {
+      inEdges: {
+        b: [
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "b",
+          },
+        ],
+        c: [
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "c",
+          },
+        ],
+        d: [
+          { type: "join", gate: "always", startStepId: "b", endStepId: "d" },
+          { type: "join", gate: "always", startStepId: "c", endStepId: "d" },
+        ],
+        e: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "d",
+            endStepId: "e",
+          },
+        ],
+        f: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "e",
+            endStepId: "f",
+          },
+        ],
+        g: [
+          {
+            type: "control",
+            gate: "onFailure",
+            startStepId: "e",
+            endStepId: "g",
+          },
+        ],
+      },
+      outEdges: {
+        a: [
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "b",
+          },
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "c",
+          },
+        ],
+        b: [{ type: "join", gate: "always", startStepId: "b", endStepId: "d" }],
+        c: [{ type: "join", gate: "always", startStepId: "c", endStepId: "d" }],
+        d: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "d",
+            endStepId: "e",
+          },
+        ],
+        e: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "e",
+            endStepId: "f",
+          },
+          {
+            type: "control",
+            gate: "onFailure",
+            startStepId: "e",
+            endStepId: "g",
+          },
+        ],
+      },
+      joinDeps: { d: ["b", "c"] },
+      nodes: ["a", "b", "c", "d", "e", "f", "g"],
+      problems: [],
+      toposort: ["a", "b", "c", "d", "e", "f", "g"],
+      refs: [],
+    };
+
+    const layout = graphLayout(fa);
+
+    expect(layout).toEqual([["a"], ["b", "c"], ["d"], ["e"], ["f", "g"]]);
+  });
+});

--- a/packages/flow-analysis/tests/toposort.test.ts
+++ b/packages/flow-analysis/tests/toposort.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { analyzeFlow } from "../src/analyze-flow.js";
+import { toposort } from "../src/toposort.js";
+import type {
+  FlowAnalysis,
+  FlowDefinition,
+  StepHttpJson,
+  StepJoin,
+  StepParallel,
+} from "@lcase/types";
+
+describe("toposort()", () => {
+  it("creates a correct toposort", () => {
+    const expectedAnalysis: FlowAnalysis = {
+      inEdges: {
+        b: [
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "b",
+          },
+        ],
+        c: [
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "c",
+          },
+        ],
+        d: [
+          { type: "join", gate: "always", startStepId: "b", endStepId: "d" },
+          { type: "join", gate: "always", startStepId: "c", endStepId: "d" },
+        ],
+        e: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "d",
+            endStepId: "e",
+          },
+        ],
+        f: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "e",
+            endStepId: "f",
+          },
+        ],
+        g: [
+          {
+            type: "control",
+            gate: "onFailure",
+            startStepId: "e",
+            endStepId: "g",
+          },
+        ],
+      },
+      outEdges: {
+        a: [
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "b",
+          },
+          {
+            type: "parallel",
+            gate: "always",
+            startStepId: "a",
+            endStepId: "c",
+          },
+        ],
+        b: [{ type: "join", gate: "always", startStepId: "b", endStepId: "d" }],
+        c: [{ type: "join", gate: "always", startStepId: "c", endStepId: "d" }],
+        d: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "d",
+            endStepId: "e",
+          },
+        ],
+        e: [
+          {
+            type: "control",
+            gate: "onSuccess",
+            startStepId: "e",
+            endStepId: "f",
+          },
+          {
+            type: "control",
+            gate: "onFailure",
+            startStepId: "e",
+            endStepId: "g",
+          },
+        ],
+      },
+      joinDeps: { d: ["b", "c"] },
+      nodes: ["a", "b", "c", "d", "e", "f", "g"],
+      problems: [],
+      refs: [],
+    };
+
+    const sorted = toposort(expectedAnalysis);
+
+    expect(sorted).toEqual(["a", "b", "c", "d", "e", "f", "g"]);
+  });
+});

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -28,6 +28,7 @@ export interface FlowServicePort {
   storeFlowInCas(path: string): Promise<void>;
   addFlow(flow: string | FlowDefinition): Promise<Result<FlowIndex, string>>;
   getAllFlowIndexes(): Promise<Result<FlowIndex[], string>>;
+  getFlowDef(hash: string): Promise<Result<FlowDefinition, string>>;
 }
 export interface ReplayServicePort {
   replayRun(runId: string): Promise<void>;

--- a/packages/services/src/flow.service.ts
+++ b/packages/services/src/flow.service.ts
@@ -119,6 +119,18 @@ export class FlowService implements FlowServicePort {
     }
   }
 
+  validateFlow(flow: unknown): Result<FlowDefinition, string> {
+    const result = FlowSchema.safeParse(flow);
+    if (!result.success) return { ok: false, error: result.error.toString() };
+
+    const fa = analyzeFlow(result.data);
+    if (fa.problems.length > 0) {
+      return { ok: false, error: "Flow had problems" };
+    }
+
+    return { ok: true, value: result.data };
+  }
+
   async storeFlowInCas(path: string) {
     const json = readFlowFile(path);
     const result = parseFlow(json);
@@ -128,6 +140,14 @@ export class FlowService implements FlowServicePort {
     } else {
       throw new Error(`Error adding flow to cas: ${result.error}`);
     }
+  }
+
+  async getFlowDef(hash: string): Promise<Result<FlowDefinition, string>> {
+    const result = await this.artifacts.getJson(hash);
+    if (!result.ok) return { ok: result.ok, error: result.error.message };
+
+    const validateResult = this.validateFlow(result.value);
+    return validateResult;
   }
 
   async addFlow(

--- a/packages/types/src/flow-analysis/types.ts
+++ b/packages/types/src/flow-analysis/types.ts
@@ -18,6 +18,7 @@ export type FlowAnalysis = {
 
   inEdges: InEdges;
   outEdges: OutEdges;
+  toposort?: string[];
 
   joinDeps: Record<StepId, StepId[]>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.1.17(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6))
+      '@xyflow/react':
+        specifier: ^12.10.0
+        version: 12.10.0(@types/react@19.2.10)(immer@11.0.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -1622,6 +1625,24 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1969,6 +1990,15 @@ packages:
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
 
+  '@xyflow/react@12.10.0':
+    resolution: {integrity: sha512-eOtz3whDMWrB4KWVatIBrKuxECHqip6PfA8fTpaS2RUGVpiEAe+nqDKsLqkViVWxDGreq0lWX71Xth/SPAzXiw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.74':
+    resolution: {integrity: sha512-7v7B/PkiVrkdZzSbL+inGAo6tkR/WQHHG0/jhSvLQToCsfa8YubOGmBYd1s08tpKpihdHDZFwzQZeR69QSBb4Q==}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -2210,6 +2240,9 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
@@ -2313,6 +2346,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -4221,6 +4292,21 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
 snapshots:
 
   7zip-bin@5.2.0: {}
@@ -5051,6 +5137,27 @@ snapshots:
     dependencies:
       '@types/node': 24.10.9
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -5538,6 +5645,29 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
+  '@xyflow/react@12.10.0(@types/react@19.2.10)(immer@11.0.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@xyflow/system': 0.0.74
+      classcat: 5.0.5
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@11.0.1)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.74':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abstract-logging@2.0.1: {}
 
   accepts@2.0.0:
@@ -5844,6 +5974,8 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  classcat@5.0.5: {}
+
   cli-truncate@2.1.0:
     dependencies:
       slice-ansi: 3.0.0
@@ -5940,6 +6072,42 @@ snapshots:
   csstype@3.1.3: {}
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   debug@4.4.3:
     dependencies:
@@ -7979,3 +8147,11 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zustand@4.5.7(@types/react@19.2.10)(immer@11.0.1)(react@19.2.0):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.10
+      immer: 11.0.1
+      react: 19.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
 
   apps/web-app:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: 1.1.8
+        version: 1.1.8
       '@lcase/flow-analysis':
         specifier: workspace:*
         version: link:../../packages/flow-analysis
@@ -780,6 +783,13 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@dagrejs/dagre@1.1.8':
+    resolution: {integrity: sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==}
+
+  '@dagrejs/graphlib@2.2.4':
+    resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
+    engines: {node: '>17.0.0'}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -2844,11 +2854,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -4429,6 +4440,12 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@dagrejs/dagre@1.1.8':
+    dependencies:
+      '@dagrejs/graphlib': 2.2.4
+
+  '@dagrejs/graphlib@2.2.4': {}
 
   '@develar/schema-utils@2.6.5':
     dependencies:


### PR DESCRIPTION
## Summary

Add an endpoint to get a flow definition `api/flows/{id}` or similar.  Using the react flow library, display the flow in a default flow graph view.

## Related Issues

- #204 

## Changes

- [x] Add react flow library to web-app.
- [x] Add http-server endpoint to serve flow definitions by id/hash.
- [x] Update flow list view to link to page with react router and load the flow visualizer.
- [x] Add flow editor page with simple layout logic to view flow, not edit yet.
