### PR TITLE
feat: add run list and detail views

### DIFF
--- a/apps/http-server/package.json
+++ b/apps/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/http-server",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/http-server/src/routes/routes.ts
+++ b/apps/http-server/src/routes/routes.ts
@@ -5,6 +5,7 @@ import { listRunsRoute } from "./runs/list.js";
 import { postFlowsFilesRoute } from "./flows/files/post.js";
 import { getFlowDefRoute } from "./flows/get-flow-def.js";
 import { requestRunsRoute } from "./runs/request.js";
+import { getRunsEventsListRoute } from "./runs/events/events.js";
 
 export const routes: FastifyPluginAsync = async (app: FastifyInstance) => {
   // api/flows
@@ -16,4 +17,7 @@ export const routes: FastifyPluginAsync = async (app: FastifyInstance) => {
   // api/runs
   await app.register(listRunsRoute, { prefix: "/api/runs" }); // get
   await app.register(requestRunsRoute, { prefix: "/api/runs" }); // post
+
+  // api/runs/details
+  await app.register(getRunsEventsListRoute, { prefix: "/api/runs/details" }); // get
 };

--- a/apps/http-server/src/routes/runs/events/events.ts
+++ b/apps/http-server/src/routes/runs/events/events.ts
@@ -1,0 +1,34 @@
+import { GetRunEventsReq, GetRunEventsRes } from "@lcase/types";
+import { FastifyInstance } from "fastify";
+
+export const getRunsEventsListRoute = async (app: FastifyInstance) => {
+  app.get<{ Querystring: GetRunEventsReq }>(
+    "/",
+    async (req, reply): Promise<GetRunEventsRes> => {
+      const { runId } = req.query;
+      if (!isRunId(runId)) return { ok: false, error: "Invalid Run ID" };
+
+      try {
+        const result = await app.services.replay.getAllEvents(runId);
+        return { ok: true, events: result.events, eventIds: result.eventIds };
+      } catch (err) {
+        console.error(err);
+        return { ok: false, error: `Error getting events` };
+      }
+    },
+  );
+};
+
+/**
+ * Narrows the type of run id if is a valid flow id string
+ * @param runId unknown
+ * @returns
+ */
+export function isRunId(runId: unknown): runId is string {
+  if (typeof runId !== "string") return false;
+  const regex = /^run-[a-zA-Z0-9\-]+$/;
+  const match = runId.match(regex);
+
+  if (!match) return false;
+  return true;
+}

--- a/apps/http-server/src/routes/runs/list.ts
+++ b/apps/http-server/src/routes/runs/list.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 
 export const listRunsRoute = async (app: FastifyInstance) => {
   app.get("/", async (req, reply) => {
-    reply.send({ ok: true });
+    const runList = await app.services.run.listAllRuns();
+    return { runList };
   });
 };

--- a/apps/web-app/src/App.tsx
+++ b/apps/web-app/src/App.tsx
@@ -6,6 +6,7 @@ import { FlowsEdit } from "./pages/FlowsEdit";
 import { Runner } from "./pages/Runner";
 import { System } from "./pages/System";
 import { Runs } from "./pages/Runs";
+import { RunDetails } from "./pages/RunDetails";
 
 export function App() {
   return (
@@ -16,9 +17,7 @@ export function App() {
       <Route path="/runner" element={<Runner />} />
       <Route path="/system" element={<System />} />
       <Route path="/runs" element={<Runs />} />
-      {/* <Route path="/sims" element={<Sims />} />
-      <Route path="/runs" element={<Runs />} />
-      <Route path="/system" element={<System />} /> */}
+      <Route path="/runs/details" element={<RunDetails />} />
       <Route path="*" element={<Dashboard />} />
     </Routes>
   );

--- a/apps/web-app/src/App.tsx
+++ b/apps/web-app/src/App.tsx
@@ -5,6 +5,7 @@ import { Flows } from "./pages/Flows";
 import { FlowsEdit } from "./pages/FlowsEdit";
 import { Runner } from "./pages/Runner";
 import { System } from "./pages/System";
+import { Runs } from "./pages/Runs";
 
 export function App() {
   return (
@@ -13,8 +14,8 @@ export function App() {
       <Route path="/flows" element={<Flows />} />
       <Route path="/flows/edit/:flowId" element={<FlowsEdit />} />
       <Route path="/runner" element={<Runner />} />
-      <Route path="/runner" element={<Runner />} />
       <Route path="/system" element={<System />} />
+      <Route path="/runs" element={<Runs />} />
       {/* <Route path="/sims" element={<Sims />} />
       <Route path="/runs" element={<Runs />} />
       <Route path="/system" element={<System />} /> */}

--- a/apps/web-app/src/components/runs/RunDetailsEventGraph.tsx
+++ b/apps/web-app/src/components/runs/RunDetailsEventGraph.tsx
@@ -1,15 +1,20 @@
-import { getEventGraphRunId } from "@/redux/slices/runner-slice";
-import { useAppSelector } from "@/redux/typed-hooks";
+import type { AnyEvent } from "@lcase/types";
 import type { EChartsOption } from "echarts";
 import EChartsReact from "echarts-for-react";
 import type { TopLevelFormatterParams } from "echarts/types/src/component/tooltip/TooltipModel.js";
 import { useMemo, useState } from "react";
 
-export function RunDetailsEventGraph() {
-  const runId = useAppSelector(getEventGraphRunId);
-  const events = useAppSelector((state) => state.events.events);
-  const runEvents = useAppSelector((state) => state.events.runEventIds);
+export type RunDetailsEventGraphProps = {
+  events: Record<string, AnyEvent>;
+  runEvents: Record<string, string[]>;
+  runId: string | null;
+};
 
+export function RunDetailsEventGraph({
+  runId,
+  runEvents,
+  events,
+}: RunDetailsEventGraphProps) {
   const eventsArr = useMemo(() => {
     if (!runId) return [];
 

--- a/apps/web-app/src/components/runs/RunDetailsTabs.tsx
+++ b/apps/web-app/src/components/runs/RunDetailsTabs.tsx
@@ -2,60 +2,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { RunDetailsFlowViewer } from "./RunDetailsFlowViewer";
 import { RunDetailsEventGraph } from "./RunDetailsEventGraph";
-import { useAppSelector } from "@/redux/typed-hooks";
-import { useGetFlowDefQuery } from "@/redux/api/flows-api";
-import { skipToken } from "@reduxjs/toolkit/query";
-import { useSearchParams } from "react-router-dom";
-import { getEventGraphRunId } from "@/redux/slices/runner-slice";
-import { useGetAllRunEventsQuery } from "@/redux/api/runs-api";
-import type { AnyEvent } from "@lcase/types";
+import { useRunDetailsData } from "./useRunDetailsData";
 
-type RunDetailsTabsProps = {
+export type RunDetailsTabsProps = {
   view: "live" | "historical";
 };
+
 export function RunDetailsTabs({ view }: RunDetailsTabsProps) {
-  const flowRunnerSelectedId = useAppSelector(
-    (state) => state.runner.flowSelectedId,
-  );
-
-  // runs/details history query string runid and flowdefhash
-  const [searchParams] = useSearchParams();
-  const runHistoryRunId = searchParams.get("runId");
-  const runDetailsFlowDefHash = searchParams.get("flowDefHash");
-
-  const runnerLiveRunId = useAppSelector(getEventGraphRunId);
-
-  const flowId =
-    view === "live"
-      ? flowRunnerSelectedId
-      : view === "historical"
-        ? runDetailsFlowDefHash
-        : null;
-
-  const runId =
-    view === "live"
-      ? runnerLiveRunId
-      : view === "historical"
-        ? runHistoryRunId
-        : null;
-
-  const flowDefQuery = useGetFlowDefQuery(flowId ?? skipToken);
-
-  const eventHistory = useGetAllRunEventsQuery(runId ? { runId } : skipToken);
-
-  const wsEvents = useAppSelector((state) => state.events.events);
-  const wsRunEventIds = useAppSelector((state) => state.events.runEventIds);
-
-  let events: Record<string, AnyEvent> = {};
-  let runEvents: Record<string, string[]> = {};
-
-  if (view === "live") {
-    events = wsEvents;
-    runEvents = wsRunEventIds;
-  } else if (view === "historical" && eventHistory.data?.ok) {
-    events = eventHistory.data.events;
-    runEvents = eventHistory.data.eventIds;
-  }
+  const { flowDef, runId, events, runEvents } = useRunDetailsData(view);
 
   return (
     <Tabs defaultValue="flow">
@@ -65,9 +19,7 @@ export function RunDetailsTabs({ view }: RunDetailsTabsProps) {
         <TabsTrigger value="events">Event Graph</TabsTrigger>
       </TabsList>
       <TabsContent value="flow">
-        <RunDetailsFlowViewer
-          flowDef={flowDefQuery?.data?.ok ? flowDefQuery.data.value : null}
-        />
+        <RunDetailsFlowViewer flowDef={flowDef} />
       </TabsContent>
       <TabsContent value="events">
         <RunDetailsEventGraph

--- a/apps/web-app/src/components/runs/RunDetailsTabs.tsx
+++ b/apps/web-app/src/components/runs/RunDetailsTabs.tsx
@@ -5,10 +5,58 @@ import { RunDetailsEventGraph } from "./RunDetailsEventGraph";
 import { useAppSelector } from "@/redux/typed-hooks";
 import { useGetFlowDefQuery } from "@/redux/api/flows-api";
 import { skipToken } from "@reduxjs/toolkit/query";
+import { useSearchParams } from "react-router-dom";
+import { getEventGraphRunId } from "@/redux/slices/runner-slice";
+import { useGetAllRunEventsQuery } from "@/redux/api/runs-api";
+import type { AnyEvent } from "@lcase/types";
 
-export function RunDetailsTabs() {
-  const flowSelectedId = useAppSelector((state) => state.runner.flowSelectedId);
-  const flowDefQuery = useGetFlowDefQuery(flowSelectedId ?? skipToken);
+type RunDetailsTabsProps = {
+  view: "live" | "historical";
+};
+export function RunDetailsTabs({ view }: RunDetailsTabsProps) {
+  const flowRunnerSelectedId = useAppSelector(
+    (state) => state.runner.flowSelectedId,
+  );
+
+  // runs/details history query string runid and flowdefhash
+  const [searchParams] = useSearchParams();
+  const runHistoryRunId = searchParams.get("runId");
+  const runDetailsFlowDefHash = searchParams.get("flowDefHash");
+
+  const runnerLiveRunId = useAppSelector(getEventGraphRunId);
+
+  const flowId =
+    view === "live"
+      ? flowRunnerSelectedId
+      : view === "historical"
+        ? runDetailsFlowDefHash
+        : null;
+
+  const runId =
+    view === "live"
+      ? runnerLiveRunId
+      : view === "historical"
+        ? runHistoryRunId
+        : null;
+
+  const flowDefQuery = useGetFlowDefQuery(flowId ?? skipToken);
+
+  const eventHistory = useGetAllRunEventsQuery(runId ? { runId } : skipToken);
+
+  const wsEvents = useAppSelector((state) => state.events.events);
+  const wsRunEventIds = useAppSelector((state) => state.events.runEventIds);
+
+  let events: Record<string, AnyEvent> = {};
+  let runEvents: Record<string, string[]> = {};
+
+  if (view === "live") {
+    events = wsEvents;
+    runEvents = wsRunEventIds;
+  } else if (view === "historical" && eventHistory.data?.ok) {
+    events = eventHistory.data.events;
+    runEvents = eventHistory.data.eventIds;
+  }
+
   return (
     <Tabs defaultValue="flow">
       <TabsList>
@@ -22,7 +70,11 @@ export function RunDetailsTabs() {
         />
       </TabsContent>
       <TabsContent value="events">
-        <RunDetailsEventGraph />
+        <RunDetailsEventGraph
+          runId={runId}
+          runEvents={runEvents}
+          events={events}
+        />
       </TabsContent>
     </Tabs>
   );

--- a/apps/web-app/src/components/runs/RunList.tsx
+++ b/apps/web-app/src/components/runs/RunList.tsx
@@ -1,0 +1,23 @@
+import { useListAllRunsQuery } from "@/redux/api/runs-api";
+import { RunListItem } from "./RunListItem";
+
+export function RunList() {
+  const { data } = useListAllRunsQuery();
+
+  if (data === undefined || data.ok === false) return <p>No runs</p>;
+
+  return (
+    <div>
+      {data.runList
+        .map((d) => d)
+        .sort(
+          (a, b) =>
+            new Date(b.endTime as string).getTime() -
+            new Date(a.endTime as string).getTime(),
+        )
+        .map((run) => (
+          <RunListItem key={run.runId} runListItem={run} />
+        ))}
+    </div>
+  );
+}

--- a/apps/web-app/src/components/runs/RunListItem.tsx
+++ b/apps/web-app/src/components/runs/RunListItem.tsx
@@ -1,12 +1,17 @@
 import type { RunListItem } from "@lcase/types";
 import { Button } from "../ui/button";
+import { Link } from "react-router-dom";
 
 export function RunListItem({ runListItem }: { runListItem: RunListItem }) {
   return (
     <div>
       <p>
         <Button variant="link" className="pl-0 cursor-pointer">
-          {runListItem.flowName}
+          <Link
+            to={`/runs/details/?runId=${runListItem.runId}&flowDefHash=${runListItem.flowDefHash}`}
+          >
+            {runListItem.flowName}
+          </Link>
         </Button>
         <span className="text-foreground/80 text-sm pr-2">
           {runListItem.flowVersion + " "}

--- a/apps/web-app/src/components/runs/RunListItem.tsx
+++ b/apps/web-app/src/components/runs/RunListItem.tsx
@@ -1,0 +1,28 @@
+import type { RunListItem } from "@lcase/types";
+import { Button } from "../ui/button";
+
+export function RunListItem({ runListItem }: { runListItem: RunListItem }) {
+  return (
+    <div>
+      <p>
+        <Button variant="link" className="pl-0 cursor-pointer">
+          {runListItem.flowName}
+        </Button>
+        <span className="text-foreground/80 text-sm pr-2">
+          {runListItem.flowVersion + " "}
+        </span>
+        <span className="text-foreground/70 text-xs">
+          {runListItem.startTime
+            ? new Date(runListItem.startTime).toLocaleTimeString() + " "
+            : ""}
+          -
+          {runListItem.endTime
+            ? " " + new Date(runListItem.endTime).toLocaleTimeString()
+            : ""}
+          {runListItem.duration ? " " + runListItem.duration + "s " : ""}
+        </span>
+      </p>
+      <p className="text-xs text-foreground/75"></p>
+    </div>
+  );
+}

--- a/apps/web-app/src/components/runs/useRunDetailsData.tsx
+++ b/apps/web-app/src/components/runs/useRunDetailsData.tsx
@@ -1,0 +1,69 @@
+import { useAppSelector } from "@/redux/typed-hooks";
+import type { RunDetailsTabsProps } from "./RunDetailsTabs";
+import { useSearchParams } from "react-router-dom";
+import { useGetFlowDefQuery } from "@/redux/api/flows-api";
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useGetAllRunEventsQuery } from "@/redux/api/runs-api";
+import type { AnyEvent } from "@lcase/types";
+import { getEventGraphRunId } from "@/redux/slices/runner-slice";
+
+export function useRunDetailsData(view: RunDetailsTabsProps["view"]) {
+  const runnerFlowId = useAppSelector((state) => state.runner.flowSelectedId);
+
+  // runs/details history query string runId and flowDefHash
+  const runHistoryParams = useRunDetailsHistoryParams();
+  const runnerRunId = useAppSelector(getEventGraphRunId);
+
+  const isLiveView = view === "live";
+  const runId = pickValue(isLiveView, runnerRunId, runHistoryParams.runId);
+  const flowId = pickValue(
+    isLiveView,
+    runnerFlowId,
+    runHistoryParams.flowDefHash,
+  );
+
+  const flowDefQuery = useGetFlowDefQuery(flowId ?? skipToken);
+
+  // REST endpoint for historical events
+  const eventHistory = useGetAllRunEventsQuery(
+    !isLiveView && runId ? { runId } : skipToken,
+  );
+
+  // WebSocket for live events
+  const wsEvents = useAppSelector((state) => state.events.events);
+  const wsRunEventIds = useAppSelector((state) => state.events.runEventIds);
+
+  // use WebSocket events for live view, REST for historical
+  const events: Record<string, AnyEvent> = isLiveView
+    ? wsEvents
+    : eventHistory.data?.ok
+      ? eventHistory.data.events
+      : {};
+
+  const runEvents: Record<string, string[]> = isLiveView
+    ? wsRunEventIds
+    : eventHistory.data?.ok
+      ? eventHistory.data.eventIds
+      : {};
+
+  const flowDef = flowDefQuery?.data?.ok ? flowDefQuery.data.value : null;
+
+  return {
+    flowDef,
+    runId,
+    events,
+    runEvents,
+  };
+}
+
+// testing abstracting out ternaries
+function pickValue<T>(isLive: boolean, liveValue: T, historicalValue: T) {
+  return isLive ? liveValue : historicalValue;
+}
+
+function useRunDetailsHistoryParams() {
+  const [searchParams] = useSearchParams();
+  const runHistoryRunId = searchParams.get("runId");
+  const runDetailsFlowDefHash = searchParams.get("flowDefHash");
+  return { runId: runHistoryRunId, flowDefHash: runDetailsFlowDefHash };
+}

--- a/apps/web-app/src/layout/Nav.tsx
+++ b/apps/web-app/src/layout/Nav.tsx
@@ -18,7 +18,7 @@ export function Nav() {
           <a href="/sims">sims</a>
         </li>
         <li>
-          <a href="/runs">runs</a>
+          <Link to="/runs">runs</Link>
         </li>
 
         <li>

--- a/apps/web-app/src/layout/Nav.tsx
+++ b/apps/web-app/src/layout/Nav.tsx
@@ -4,24 +4,20 @@ import { Link } from "react-router-dom";
 export function Nav() {
   return (
     <nav className="flex items-center">
-      <ul className="flex gap-2">
-        <li>
+      <ul className="flex gap-2 ">
+        <li className="hover:text-cyan-700 hover:dark:text-cyan-500">
           <Link to="/">dashboard</Link>
         </li>
-        <li>
+        <li className="hover:text-cyan-700 hover:dark:text-cyan-500">
           <Link to="/runner">runner</Link>
         </li>
-        <li>
+        <li className="hover:text-cyan-700 hover:dark:text-cyan-500">
           <Link to="/flows">flows</Link>
         </li>
-        <li>
-          <a href="/sims">sims</a>
-        </li>
-        <li>
+        <li className="hover:text-cyan-700 hover:dark:text-cyan-500">
           <Link to="/runs">runs</Link>
         </li>
-
-        <li>
+        <li className="hover:text-cyan-700 hover:dark:text-cyan-500">
           <Link to="/system">system</Link>
         </li>
       </ul>

--- a/apps/web-app/src/pages/RunDetails.tsx
+++ b/apps/web-app/src/pages/RunDetails.tsx
@@ -1,0 +1,26 @@
+import { Header } from "../layout/Header";
+import { Main } from "../layout/Main";
+
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { RunDetailsTabs } from "@/components/runs/RunDetailsTabs";
+// import { useGetFlowDefQuery } from "@/redux/api/flows-api";
+// import { skipToken } from "@reduxjs/toolkit/query";
+
+export function RunDetails() {
+  return (
+    <div id="page-wrapper">
+      <Header />
+      <Main>
+        <h2 className="text-xl font-bold mb-5">Run Details</h2>
+        <p className="text-sm mb-3">
+          <Button variant="link" className="pl-0">
+            <Link to="/runs">runs</Link>
+          </Button>
+          / details
+        </p>
+        <RunDetailsTabs view="historical" />
+      </Main>
+    </div>
+  );
+}

--- a/apps/web-app/src/pages/Runner.tsx
+++ b/apps/web-app/src/pages/Runner.tsx
@@ -12,7 +12,7 @@ export function Runner() {
         <div className="flex justify-between mb-4">
           <RunnerFlowSelector />
         </div>
-        <RunDetailsTabs />
+        <RunDetailsTabs view="live" />
       </Main>
     </div>
   );

--- a/apps/web-app/src/pages/Runs.tsx
+++ b/apps/web-app/src/pages/Runs.tsx
@@ -1,0 +1,15 @@
+import { RunList } from "@/components/runs/RunList";
+import { Header } from "@/layout/Header";
+import { Main } from "@/layout/Main";
+
+export function Runs() {
+  return (
+    <div id="page-wrapper">
+      <Header />
+      <Main>
+        <h2 className="text-xl font-bold mb-5">Runs</h2>
+        <RunList />
+      </Main>
+    </div>
+  );
+}

--- a/apps/web-app/src/redux/api/runs-api.ts
+++ b/apps/web-app/src/redux/api/runs-api.ts
@@ -1,4 +1,4 @@
-import type { PostRunsReq, PostRunsRes } from "@lcase/types";
+import type { GetRunsRes, PostRunsReq, PostRunsRes } from "@lcase/types";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const runsApi = createApi({
@@ -13,7 +13,13 @@ export const runsApi = createApi({
         headers: { "Content-Type": "application/json" },
       }),
     }),
+    listAllRuns: builder.query<GetRunsRes, void>({
+      query: () => ({
+        url: "runs",
+        method: "GET",
+      }),
+    }),
   }),
 });
 
-export const { useRequestRunMutation } = runsApi;
+export const { useRequestRunMutation, useListAllRunsQuery } = runsApi;

--- a/apps/web-app/src/redux/api/runs-api.ts
+++ b/apps/web-app/src/redux/api/runs-api.ts
@@ -1,4 +1,10 @@
-import type { GetRunsRes, PostRunsReq, PostRunsRes } from "@lcase/types";
+import type {
+  GetRunEventsReq,
+  GetRunEventsRes,
+  GetRunsRes,
+  PostRunsReq,
+  PostRunsRes,
+} from "@lcase/types";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const runsApi = createApi({
@@ -19,7 +25,17 @@ export const runsApi = createApi({
         method: "GET",
       }),
     }),
+    getAllRunEvents: builder.query<GetRunEventsRes, GetRunEventsReq>({
+      query: (args: GetRunEventsReq) => ({
+        url: `runs/details?runId=${args.runId}`,
+        method: "GET",
+      }),
+    }),
   }),
 });
 
-export const { useRequestRunMutation, useListAllRunsQuery } = runsApi;
+export const {
+  useRequestRunMutation,
+  useListAllRunsQuery,
+  useGetAllRunEventsQuery,
+} = runsApi;

--- a/apps/web-app/src/redux/middleware/route-event.ts
+++ b/apps/web-app/src/redux/middleware/route-event.ts
@@ -1,13 +1,13 @@
 import type { AnyEvent } from "@lcase/types";
 import { createListenerMiddleware, type Dispatch } from "@reduxjs/toolkit";
-import { eventsBatch, wsConnect } from "./ws";
+import { eventsBatch } from "./ws";
 
 export const routeEventListenerMiddleware = createListenerMiddleware();
 
 export function routeEvent(dispatch: Dispatch, event: AnyEvent) {
   switch (event.type) {
     case "run.started": {
-      dispatch(wsConnect({ url: "" }));
+      // dispatch(wsConnect({ url: "" })); no custom dispatching yet
       return;
     }
     default:

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/adapters",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/adapters/src/run-index-store/fs-run-index-store.ts
+++ b/packages/adapters/src/run-index-store/fs-run-index-store.ts
@@ -33,4 +33,21 @@ export class FsRunIndexStore implements RunIndexStorePort {
       console.log(`Error reading index for run:${runId}. ${e}`);
     }
   }
+
+  async getAllRunIds(): Promise<string[]> {
+    try {
+      const files = await fs.promises.readdir(this.dir);
+
+      const fileNames: string[] = [];
+      if (!files || files.length === 0) return [];
+      for (const file of files) {
+        if (!file.endsWith(".index.json")) continue;
+        fileNames.push(file.replace(".index.json", ""));
+      }
+      return fileNames;
+    } catch (err) {
+      console.log(`Error reading directory ${this.dir}: ${err}`);
+      return [];
+    }
+  }
 }

--- a/packages/ports/package.json
+++ b/packages/ports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/ports",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": "true",
   "type": "module",
   "exports": {

--- a/packages/ports/src/replay/replay-engine.port.ts
+++ b/packages/ports/src/replay/replay-engine.port.ts
@@ -1,4 +1,7 @@
+import { AnyEvent } from "@lcase/types";
+
 export interface ReplayEnginePort {
   replayAllEvents(runId: string): Promise<void>;
   emitReplayMode(runId: string, enableSideEffects: boolean): Promise<void>;
+  getAllEvents(runId: string): Promise<AnyEvent[]>;
 }

--- a/packages/ports/src/run-index-store/run-index-store.port.ts
+++ b/packages/ports/src/run-index-store/run-index-store.port.ts
@@ -12,4 +12,5 @@ export type RunIndexEvent =
 export interface RunIndexStorePort {
   putRunIndex(index: RunIndex, runId: string): Promise<void>;
   getRunIndex(runId: string): Promise<RunIndex | undefined>;
+  getAllRunIds(): Promise<string[]>;
 }

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -1,4 +1,9 @@
-import type { FlowDefinition, FlowIndex, Result } from "@lcase/types";
+import type {
+  FlowDefinition,
+  FlowIndex,
+  Result,
+  RunListItem,
+} from "@lcase/types";
 import type { EventSink } from "../observability/observability-sink.port.js";
 import type { RuntimeStatus } from "../controller.port.js";
 import type { FlowList } from "../flow/list.type.js";
@@ -48,6 +53,7 @@ export interface RunServicePort {
     runId?: string,
   ): Promise<void>;
   makeRunId(): string;
+  listAllRuns(): Promise<RunListItem[]>;
 }
 
 export interface WsServicePort {

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -1,4 +1,5 @@
 import type {
+  AnyEvent,
   FlowDefinition,
   FlowIndex,
   Result,
@@ -38,6 +39,10 @@ export interface FlowServicePort {
 }
 export interface ReplayServicePort {
   replayRun(runId: string): Promise<void>;
+  getAllEvents(runId: string): Promise<{
+    eventIds: Record<string, string[]>;
+    events: Record<string, AnyEvent>;
+  }>;
 }
 
 export interface SystemServicePort {

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1,11 +1,12 @@
 import type { EventStorePort } from "@lcase/ports/event-store";
 import type { ReplayEnginePort } from "@lcase/ports/replay";
 import type { EmitterFactoryPort, EventBusPort } from "@lcase/ports";
+import { AnyEvent } from "@lcase/types";
 export class ReplayEngine implements ReplayEnginePort {
   constructor(
     private readonly store: EventStorePort,
     private readonly bus: EventBusPort,
-    private readonly ef: EmitterFactoryPort
+    private readonly ef: EmitterFactoryPort,
   ) {}
 
   async replayAllEvents(runId: string) {
@@ -26,5 +27,13 @@ export class ReplayEngine implements ReplayEnginePort {
     await emitter.emit("replay.mode.submitted", {
       enableSideEffects,
     });
+  }
+
+  async getAllEvents(runId: string): Promise<AnyEvent[]> {
+    const events: AnyEvent[] = [];
+    for await (const event of this.store.iterateAllEvents(runId)) {
+      events.push(event);
+    }
+    return events;
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/runtime",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/src/create-services.ts
+++ b/packages/runtime/src/create-services.ts
@@ -15,18 +15,20 @@ import path from "node:path";
 
 export function createServices(config: RuntimeConfig): ServicesPort {
   const ctx = makeRuntimeContext(config);
-
+  const flowIndexStore = new FsFlowIndexStore(
+    path.join(process.cwd(), "lcase-db/flows/index"),
+  );
   const flow = new FlowService(
     ctx.bus,
     ctx.ef,
     new FlowStoreFs(),
     ctx.artifacts,
-    new FsFlowIndexStore(path.join(process.cwd(), "lcase-db/flows/index")),
+    flowIndexStore,
   );
   const replay = new ReplayService(ctx.replay);
   const sim = new SimService(ctx.artifacts, ctx.ef, ctx.runIndexStore);
   const ws = new WsService(ctx.bus);
-  const run = new RunService(ctx.ef);
+  const run = new RunService(ctx.ef, ctx.runIndexStore, flowIndexStore);
 
   const system = new SystemService({
     bus: ctx.bus,

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/services",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/services/src/replay.service.ts
+++ b/packages/services/src/replay.service.ts
@@ -1,10 +1,32 @@
 import type { ReplayServicePort } from "@lcase/ports";
 import type { ReplayEnginePort } from "@lcase/ports/replay";
+import { AnyEvent } from "@lcase/types";
+
+type RunId = string;
+type EventId = string;
 export class ReplayService implements ReplayServicePort {
   constructor(private replay: ReplayEnginePort) {}
 
   async replayRun(runId: string) {
     await this.replay.emitReplayMode(runId, false);
     await this.replay.replayAllEvents(runId);
+  }
+
+  async getAllEvents(runId: string) {
+    const rawEvents = await this.replay.getAllEvents(runId);
+
+    const formattedEvents: {
+      eventIds: Record<RunId, EventId[]>;
+      events: Record<EventId, AnyEvent>;
+    } = {
+      eventIds: {},
+      events: {},
+    };
+
+    for (const event of rawEvents) {
+      formattedEvents.events[event.id] ??= event;
+      (formattedEvents.eventIds[runId] ??= []).push(event.id);
+    }
+    return formattedEvents;
   }
 }

--- a/packages/services/src/run.service.ts
+++ b/packages/services/src/run.service.ts
@@ -1,8 +1,19 @@
-import { EmitterFactoryPort, EventBusPort, RunServicePort } from "@lcase/ports";
+import {
+  EmitterFactoryPort,
+  EventBusPort,
+  FlowIndexStorePort,
+  RunIndexStorePort,
+  RunServicePort,
+} from "@lcase/ports";
 import { createRunId, runFlow } from "@lcase/run-flow";
+import { listAllRuns } from "@lcase/run-history";
 
 export class RunService implements RunServicePort {
-  constructor(private readonly ef: EmitterFactoryPort) {}
+  constructor(
+    private readonly ef: EmitterFactoryPort,
+    private readonly runStore: RunIndexStorePort,
+    private readonly flowStore: FlowIndexStorePort,
+  ) {}
 
   async requestRun(flowDefHash: string, source: string, runId?: string) {
     await runFlow(flowDefHash, this.ef, source, runId);
@@ -10,5 +21,10 @@ export class RunService implements RunServicePort {
 
   makeRunId() {
     return createRunId();
+  }
+
+  async listAllRuns() {
+    const runList = await listAllRuns(this.runStore, this.flowStore);
+    return runList;
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/types",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": "true",
   "type": "module",
   "exports": {

--- a/packages/types/src/api/index.ts
+++ b/packages/types/src/api/index.ts
@@ -2,3 +2,4 @@ export * from "./flows/post-flow-json.js";
 export * from "./flows/get-flows-json.js";
 export * from "./flows/files/post-flow-file.js";
 export * from "./runs/post-runs.js";
+export * from "./runs/get-runs.js";

--- a/packages/types/src/api/index.ts
+++ b/packages/types/src/api/index.ts
@@ -3,3 +3,4 @@ export * from "./flows/get-flows-json.js";
 export * from "./flows/files/post-flow-file.js";
 export * from "./runs/post-runs.js";
 export * from "./runs/get-runs.js";
+export * from "./runs/get-run-events.js";

--- a/packages/types/src/api/runs/get-run-events.ts
+++ b/packages/types/src/api/runs/get-run-events.ts
@@ -1,0 +1,12 @@
+import { AnyEvent } from "../../events/any-event.js";
+
+type RunId = string;
+type EventId = string;
+export type GetRunEventsReq = { runId: string };
+export type GetRunEventsRes =
+  | {
+      ok: true;
+      events: Record<EventId, AnyEvent>;
+      eventIds: Record<RunId, EventId[]>;
+    }
+  | { ok: false; error: string };

--- a/packages/types/src/api/runs/get-runs.ts
+++ b/packages/types/src/api/runs/get-runs.ts
@@ -1,0 +1,5 @@
+import type { RunListItem } from "../../run-index-store/run-list.js";
+
+export type GetRunsRes =
+  | { ok: true; runList: RunListItem[] }
+  | { ok: false; error: string };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -46,3 +46,5 @@ export * from "./flow-index-store/flow-index.js";
 
 // api index
 export * from "./api/index.js";
+
+export * from "./run-index-store/run-list.js";

--- a/packages/types/src/run-index-store/run-list.ts
+++ b/packages/types/src/run-index-store/run-list.ts
@@ -1,0 +1,11 @@
+export type RunListItem = {
+  runId: string;
+  flowName: string;
+  flowVersion: string;
+  flowDefHash: string;
+  startTime?: string;
+  endTime?: string;
+  duration?: number;
+  forkSpecHash?: string;
+  parentId?: string;
+};

--- a/packages/use-cases/run-history/package.json
+++ b/packages/use-cases/run-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/run-history",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/use-cases/run-history/src/index.ts
+++ b/packages/use-cases/run-history/src/index.ts
@@ -2,3 +2,4 @@ export * from "./update-run-index.js";
 export * from "./get-step-output-hashes.js";
 export * from "./init-run-index.js";
 export * from "./utils/has-run-id.js";
+export * from "./list-all-runs.js";

--- a/packages/use-cases/run-history/src/list-all-runs.ts
+++ b/packages/use-cases/run-history/src/list-all-runs.ts
@@ -1,0 +1,30 @@
+import { FlowIndexStorePort, RunIndexStorePort } from "@lcase/ports";
+import type { RunListItem } from "@lcase/types";
+
+export async function listAllRuns(
+  store: RunIndexStorePort,
+  flowStore: FlowIndexStorePort,
+) {
+  const runList: RunListItem[] = [];
+
+  const runIds = await store.getAllRunIds();
+  for (const runId of runIds) {
+    const runIndex = await store.getRunIndex(runId);
+    if (!runIndex) continue;
+    if (!runIndex.flowDefHash) continue;
+
+    const flowIndexResult = await flowStore.getFlowIndex(runIndex.flowDefHash);
+    if (!flowIndexResult.ok) continue;
+    runList.push({
+      runId,
+      flowName: flowIndexResult.value.name,
+      flowVersion: flowIndexResult.value.version,
+      flowDefHash: runIndex.flowDefHash,
+      startTime: runIndex.startTime,
+      endTime: runIndex.endTime,
+      duration: runIndex.duration,
+      parentId: runIndex.parentId,
+    });
+  }
+  return runList;
+}


### PR DESCRIPTION
## Summary

Add a view that shows all previous runs.  Allow users to drill down into individual runs to see their results, flow diagraph, event history.

## Related Issues

- #208 

## Changes

- Add run list view to ui, supported by new use cases and an addition method on the run services class.
- Add historical run view to ui, with event graph built from replay event store.