### PR TITLE
feat(web-app): add artifact list and viewer for historical runs

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/cli",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/http-server/src/routes/artifacts/get-artifact.ts
+++ b/apps/http-server/src/routes/artifacts/get-artifact.ts
@@ -1,0 +1,16 @@
+import type { FastifyInstance } from "fastify/types/instance.js";
+import { isHash } from "../../utils/is-hash.js";
+import type { GetArtifactReq, GetArtifactRes } from "@lcase/types";
+
+export const getArtifactRoute = async (app: FastifyInstance) => {
+  app.get<{ Params: GetArtifactReq }>(
+    "/:hash",
+    async (req, reply): Promise<GetArtifactRes> => {
+      const { hash } = req.params;
+      if (!isHash(hash)) return { ok: false, error: "Invalid hash" };
+      const artifact = await app.services.artifact.getArtifact(hash);
+      if (!artifact.ok) return artifact;
+      return { ok: true, jsonValue: artifact.value };
+    },
+  );
+};

--- a/apps/http-server/src/routes/routes.ts
+++ b/apps/http-server/src/routes/routes.ts
@@ -9,6 +9,8 @@ import { getRunsEventsListRoute } from "./runs/events/events.js";
 import { simsListRoute } from "./sims/list.js";
 import { postSimsRoute } from "./sims/post.js";
 import { getSimSpec } from "./sims/get-sim-spec.js";
+import { getRunIndex } from "./runs/get-run-index.js";
+import { getArtifactRoute } from "./artifacts/get-artifact.js";
 
 export const routes: FastifyPluginAsync = async (app: FastifyInstance) => {
   // api/flows
@@ -19,6 +21,7 @@ export const routes: FastifyPluginAsync = async (app: FastifyInstance) => {
 
   // api/runs
   await app.register(listRunsRoute, { prefix: "/api/runs" }); // get
+  await app.register(getRunIndex, { prefix: "/api/runs" });
   await app.register(requestRunsRoute, { prefix: "/api/runs" }); // post
 
   // api/runs/details
@@ -28,4 +31,7 @@ export const routes: FastifyPluginAsync = async (app: FastifyInstance) => {
   await app.register(simsListRoute, { prefix: "/api/sims" });
   await app.register(postSimsRoute, { prefix: "/api/sims" });
   await app.register(getSimSpec, { prefix: "/api/sims" });
+
+  // api/artifacts
+  await app.register(getArtifactRoute, { prefix: "/api/artifacts" });
 };

--- a/apps/http-server/src/routes/runs/events/events.ts
+++ b/apps/http-server/src/routes/runs/events/events.ts
@@ -1,5 +1,6 @@
 import { GetRunEventsReq, GetRunEventsRes } from "@lcase/types";
 import { FastifyInstance } from "fastify";
+import { isRunId } from "../../../utils/is-run-id.js";
 
 export const getRunsEventsListRoute = async (app: FastifyInstance) => {
   app.get<{ Querystring: GetRunEventsReq }>(
@@ -18,17 +19,3 @@ export const getRunsEventsListRoute = async (app: FastifyInstance) => {
     },
   );
 };
-
-/**
- * Narrows the type of run id if is a valid flow id string
- * @param runId unknown
- * @returns
- */
-export function isRunId(runId: unknown): runId is string {
-  if (typeof runId !== "string") return false;
-  const regex = /^run-[a-zA-Z0-9\-]+$/;
-  const match = runId.match(regex);
-
-  if (!match) return false;
-  return true;
-}

--- a/apps/http-server/src/routes/runs/get-run-index.ts
+++ b/apps/http-server/src/routes/runs/get-run-index.ts
@@ -1,0 +1,18 @@
+import { FastifyInstance } from "fastify";
+import { isRunId } from "../../utils/is-run-id.js";
+import { GetRunIndexRes } from "@lcase/types";
+
+export const getRunIndex = async (app: FastifyInstance) => {
+  app.get<{ Params: { runId: unknown } }>(
+    "/:runId",
+    async (req, reply): Promise<GetRunIndexRes> => {
+      const { runId } = req.params;
+      if (!isRunId(runId)) return { ok: false, error: "Invalid run id" };
+
+      const runIndex = await app.services.run.getRunIndex(runId);
+      if (!runIndex.ok) return { ok: false, error: runIndex.error };
+
+      return { ok: true, index: runIndex.value };
+    },
+  );
+};

--- a/apps/http-server/src/utils/is-run-id.ts
+++ b/apps/http-server/src/utils/is-run-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Narrows the type if its a valid run id string
+ * @param runId unknown
+ * @returns
+ */
+export function isRunId(runId: unknown): runId is string {
+  if (typeof runId !== "string") return false;
+  const regex = /^run-[a-zA-Z0-9\-]+$/;
+  const match = runId.match(regex);
+
+  if (!match) return false;
+  return true;
+}

--- a/apps/web-app/src/components/runs/RunArtifactList.tsx
+++ b/apps/web-app/src/components/runs/RunArtifactList.tsx
@@ -1,0 +1,31 @@
+import { useGetRunIndexQuery } from "@/redux/api/runs-api";
+import { skipToken } from "@reduxjs/toolkit/query";
+import { RunArtifactListItem } from "./RunArtifactListItem";
+
+export function RunArtifactList({ runId }: { runId: string | null }) {
+  const { data } = useGetRunIndexQuery(runId ? { runId } : skipToken);
+
+  if (!data) return <div>No artifacts found yet</div>;
+  if (!data?.ok) return <div>Error getting run index: {data.error}</div>;
+
+  return (
+    <div>
+      {data.index.flowDefHash ? (
+        <RunArtifactListItem
+          item="Flow Definition Hash"
+          hash={data.index.flowDefHash}
+        />
+      ) : null}
+      {Object.entries(data.index.steps).map(([stepName, details]) => {
+        if (!details.outputHash) return null;
+        return (
+          <RunArtifactListItem
+            item={"Step: " + stepName}
+            hash={details.outputHash}
+            key={details.outputHash}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web-app/src/components/runs/RunArtifactListItem.tsx
+++ b/apps/web-app/src/components/runs/RunArtifactListItem.tsx
@@ -1,0 +1,46 @@
+import { useAppDispatch } from "@/redux/typed-hooks";
+import { Button } from "../ui/button";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from "../ui/item";
+import {
+  setRunsActiveTab,
+  setRunsSelectedArtifactHash,
+} from "@/redux/slices/runs-slice";
+
+type RunArtifactItemProps = {
+  item: string;
+  hash: string | null;
+};
+export function RunArtifactListItem({ item, hash }: RunArtifactItemProps) {
+  const dispatch = useAppDispatch();
+
+  const handleView = () => {
+    if (!hash) return;
+    dispatch(setRunsSelectedArtifactHash(hash));
+    dispatch(setRunsActiveTab("artifactViewer"));
+  };
+  return (
+    <div>
+      <Item variant="muted">
+        <ItemContent>
+          <ItemTitle>{item}</ItemTitle>
+          <ItemDescription>Hash: {hash}</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button
+            variant="outline"
+            onClick={handleView}
+            className="cursor-pointer"
+          >
+            View
+          </Button>
+        </ItemActions>
+      </Item>
+    </div>
+  );
+}

--- a/apps/web-app/src/components/runs/RunArtifactViewer.tsx
+++ b/apps/web-app/src/components/runs/RunArtifactViewer.tsx
@@ -11,7 +11,9 @@ export function RunArtifactViewer() {
     return <div> Error getting artifact: {artifact.data.error}</div>;
   return (
     <div>
-      <pre>{JSON.stringify(artifact.data.jsonValue, null, 2)}</pre>
+      <pre className="text-sm/4.5">
+        {JSON.stringify(artifact.data.jsonValue, null, 2)}
+      </pre>
     </div>
   );
 }

--- a/apps/web-app/src/components/runs/RunArtifactViewer.tsx
+++ b/apps/web-app/src/components/runs/RunArtifactViewer.tsx
@@ -1,0 +1,17 @@
+import { useGetArtifactQuery } from "@/redux/api/artifacts-api";
+import { getRunsSelectedArtifactHash } from "@/redux/slices/runs-slice";
+import { useAppSelector } from "@/redux/typed-hooks";
+import { skipToken } from "@reduxjs/toolkit/query";
+
+export function RunArtifactViewer() {
+  const hash = useAppSelector(getRunsSelectedArtifactHash);
+  const artifact = useGetArtifactQuery(hash ? { hash } : skipToken);
+  if (!artifact.data) return <div>No artifact selected</div>;
+  if (!artifact.data.ok)
+    return <div> Error getting artifact: {artifact.data.error}</div>;
+  return (
+    <div>
+      <pre>{JSON.stringify(artifact.data.jsonValue, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/web-app/src/components/runs/RunDetailsTabs.tsx
+++ b/apps/web-app/src/components/runs/RunDetailsTabs.tsx
@@ -17,12 +17,14 @@ import {
   selectEventById,
 } from "@/redux/slices/events-slice";
 import { shallowEqual } from "react-redux";
+import { RunArtifactList } from "./RunArtifactList";
+import { RunArtifactViewer } from "./RunArtifactViewer";
 
 export type RunDetailsTabsProps = {
   view: "live" | "historical";
 };
 
-export function RunDetailsTabs() {
+export function RunDetailsTabs({ view }: RunDetailsTabsProps) {
   const { activeTab, setActiveTab, selectedEventId, runId, flowDefHash } =
     useRunDetailsController();
   // const allEvents = useAppSelector((state) => state.events.events);
@@ -54,7 +56,13 @@ export function RunDetailsTabs() {
 
         <TabsTrigger value="events">Event Graph</TabsTrigger>
         <TabsTrigger value="details">Event Details</TabsTrigger>
-        <TabsTrigger value="artifact">Artifact</TabsTrigger>
+
+        {view === "historical" ? (
+          <>
+            <TabsTrigger value="artifacts">Artifact List</TabsTrigger>
+            <TabsTrigger value="artifactViewer">Artifact Viewer</TabsTrigger>
+          </>
+        ) : null}
       </TabsList>
       <TabsContent value="flow">
         <RunDetailsFlowViewer flowDef={flowDef} />
@@ -65,7 +73,16 @@ export function RunDetailsTabs() {
       <TabsContent value="details">
         <EventDetails event={selectedEvent} />
       </TabsContent>
-      <TabsContent value="artifact">Event Details</TabsContent>
+      {view === "historical" ? (
+        <>
+          <TabsContent value="artifacts">
+            <RunArtifactList runId={runId} />
+          </TabsContent>
+          <TabsContent value="artifactViewer">
+            <RunArtifactViewer />
+          </TabsContent>
+        </>
+      ) : null}
     </Tabs>
   );
 }

--- a/apps/web-app/src/components/runs/RunList.tsx
+++ b/apps/web-app/src/components/runs/RunList.tsx
@@ -1,8 +1,12 @@
 import { useListAllRunsQuery } from "@/redux/api/runs-api";
 import { RunListItem } from "./RunListItem";
+import { useAppDispatch } from "@/redux/typed-hooks";
+import { setRunsSelectedArtifactHash } from "@/redux/slices/runs-slice";
 
 export function RunList() {
   const { data } = useListAllRunsQuery();
+  const dispatch = useAppDispatch();
+  dispatch(setRunsSelectedArtifactHash(null));
 
   if (data === undefined || data.ok === false) return <p>No runs</p>;
   const runs = [...data.runList];

--- a/apps/web-app/src/components/runs/use-run-details-controller.ts
+++ b/apps/web-app/src/components/runs/use-run-details-controller.ts
@@ -1,6 +1,12 @@
 import { createContext, useContext } from "react";
 
-export type Tab = "flow" | "events" | "details" | "artifacts";
+export type Tab =
+  | "flow"
+  | "events"
+  | "details"
+  | "artifacts"
+  | "artifactViewer";
+
 export type RunDetailsController = {
   selectedEventId: string | null;
   setSelectedEventId: (id: string | null) => void;

--- a/apps/web-app/src/pages/RunDetails.tsx
+++ b/apps/web-app/src/pages/RunDetails.tsx
@@ -48,7 +48,7 @@ export function RunDetails() {
           / details
         </p>
         <RunDetailsControllerProvider value={controller}>
-          <RunDetailsTabs />
+          <RunDetailsTabs view="historical" />
         </RunDetailsControllerProvider>
       </Main>
     </div>

--- a/apps/web-app/src/pages/Runner.tsx
+++ b/apps/web-app/src/pages/Runner.tsx
@@ -51,7 +51,7 @@ export function Runner() {
         </div>
 
         <RunDetailsControllerProvider value={controller}>
-          <RunDetailsTabs />
+          <RunDetailsTabs view="live" />
         </RunDetailsControllerProvider>
       </Main>
     </div>

--- a/apps/web-app/src/redux/api/artifacts-api.ts
+++ b/apps/web-app/src/redux/api/artifacts-api.ts
@@ -1,0 +1,17 @@
+import type { GetArtifactReq, GetArtifactRes } from "@lcase/types";
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const artifactsApi = createApi({
+  reducerPath: "artifactsApi",
+  baseQuery: fetchBaseQuery({ baseUrl: "http://localhost:3000/api/" }),
+  endpoints: (builder) => ({
+    getArtifact: builder.query<GetArtifactRes, GetArtifactReq>({
+      query: (args) => ({
+        url: `artifacts/${args.hash}`,
+        method: "GET",
+      }),
+    }),
+  }),
+});
+
+export const { useGetArtifactQuery } = artifactsApi;

--- a/apps/web-app/src/redux/api/runs-api.ts
+++ b/apps/web-app/src/redux/api/runs-api.ts
@@ -1,6 +1,8 @@
 import type {
   GetRunEventsReq,
   GetRunEventsRes,
+  GetRunIndexReq,
+  GetRunIndexRes,
   GetRunsRes,
   PostRunsReq,
   PostRunsRes,
@@ -27,6 +29,12 @@ export const runsApi = createApi({
       }),
     }),
 
+    getRunIndex: builder.query<GetRunIndexRes, GetRunIndexReq>({
+      query: (arg) => ({
+        url: `runs/${arg.runId}`,
+        method: "GET",
+      }),
+    }),
     getAllRunEvents: builder.query<GetRunEventsRes, GetRunEventsReq>({
       query: (args: GetRunEventsReq) => ({
         url: `runs/details?runId=${args.runId}`,
@@ -50,4 +58,5 @@ export const {
   useRequestRunMutation,
   useListAllRunsQuery,
   useGetAllRunEventsQuery,
+  useGetRunIndexQuery,
 } = runsApi;

--- a/apps/web-app/src/redux/slices/runs-slice.ts
+++ b/apps/web-app/src/redux/slices/runs-slice.ts
@@ -14,6 +14,7 @@ type RunState = {
   enableSim: boolean;
   activeTab: Tab;
   selectedEventId: string | null;
+  selectedArtifactHash: string | null;
 };
 const initialState: RunState = {
   flowHash: null,
@@ -28,6 +29,7 @@ const initialState: RunState = {
   activeTab: "flow",
 
   selectedEventId: null,
+  selectedArtifactHash: null,
 };
 
 type FlowHash = string;
@@ -53,6 +55,12 @@ export const runsSlice = createSlice({
     setRunsSelectedEventId: (state, action: PayloadAction<string | null>) => {
       state.selectedEventId = action.payload;
     },
+    setRunsSelectedArtifactHash: (
+      state,
+      action: PayloadAction<string | null>,
+    ) => {
+      state.selectedArtifactHash = action.payload;
+    },
   },
 });
 
@@ -63,6 +71,7 @@ export const {
   setRunsRunId,
   setRunsActiveTab,
   setRunsSelectedEventId,
+  setRunsSelectedArtifactHash,
 } = runsSlice.actions;
 export const getRunsFlowHash = (state: RootState) => {
   return state.runs.flowHash;
@@ -73,6 +82,9 @@ export const selectFlows = (state: RootState) => {
 };
 export const getEventGraphRunId = (state: RootState) => {
   return state.runner.eventGraphRunId;
+};
+export const getRunsSelectedArtifactHash = (state: RootState) => {
+  return state.runs.selectedArtifactHash;
 };
 
 export const getRunsSelectedEventId = (state: RootState) => {

--- a/apps/web-app/src/redux/store.ts
+++ b/apps/web-app/src/redux/store.ts
@@ -10,6 +10,7 @@ import { runsApi } from "./api/runs-api";
 import { simsSlice } from "./slices/sims-slice";
 import { simsApi } from "./api/sims-api";
 import { runsSlice } from "./slices/runs-slice";
+import { artifactsApi } from "./api/artifacts-api";
 
 // reducers are separated out to type RootState independently of store,
 // because middleware in the store needs RootState.  This avoids circular
@@ -24,6 +25,7 @@ export const rootReducer = combineReducers({
   [flowsApi.reducerPath]: flowsApi.reducer,
   [runsApi.reducerPath]: runsApi.reducer,
   [simsApi.reducerPath]: simsApi.reducer,
+  [artifactsApi.reducerPath]: artifactsApi.reducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;
@@ -37,6 +39,7 @@ export const store = configureStore({
         flowsApi.middleware,
         runsApi.middleware,
         simsApi.middleware,
+        artifactsApi.middleware,
         createWsMiddleware(),
       ),
 });

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -5,6 +5,7 @@ import type {
   ForkSpec,
   ForkSpecIndex,
   Result,
+  RunIndex,
   RunListItem,
 } from "@lcase/types";
 import type { EventSink } from "../observability/observability-sink.port.js";
@@ -19,6 +20,7 @@ export interface ServicesPort {
   system: SystemServicePort;
   run: RunServicePort;
   ws: WsServicePort;
+  artifact: ArtifactServicePort;
 }
 
 export type ForkSpecDetails = {
@@ -75,10 +77,15 @@ export interface RunServicePort {
   requestRun(request: RunRequest): Promise<void>;
   makeRunId(): string;
   listAllRuns(): Promise<RunListItem[]>;
+  getRunIndex(runId: string): Promise<Result<RunIndex, string>>;
 }
 
 export interface WsServicePort {
   monitorRun(runId: string, socket: WebSocket): void;
   stopMonitoringRun(runId: string): void;
   start(): Promise<void>;
+}
+
+export interface ArtifactServicePort {
+  getArtifact(hash: string): Promise<Result<JsonValue, string>>;
 }

--- a/packages/runtime/src/create-services.ts
+++ b/packages/runtime/src/create-services.ts
@@ -1,4 +1,5 @@
 import {
+  ArtifactService,
   FlowService,
   ReplayService,
   RunService,
@@ -41,6 +42,8 @@ export function createServices(config: RuntimeConfig): ServicesPort {
   const ws = new WsService(ctx.bus);
   const run = new RunService(ctx.ef, ctx.runIndexStore, flowIndexStore);
 
+  const artifact = new ArtifactService(ctx.artifacts);
+
   const system = new SystemService({
     bus: ctx.bus,
     ef: ctx.ef,
@@ -52,5 +55,5 @@ export function createServices(config: RuntimeConfig): ServicesPort {
     worker: ctx.worker,
   });
 
-  return { flow, replay, sim, system, run, ws };
+  return { flow, replay, sim, system, run, ws, artifact };
 }

--- a/packages/services/src/artifact.service.ts
+++ b/packages/services/src/artifact.service.ts
@@ -1,0 +1,12 @@
+import { ArtifactServicePort, ArtifactsPort } from "@lcase/ports";
+import type { JsonValue, Result } from "@lcase/types";
+
+export class ArtifactService implements ArtifactServicePort {
+  constructor(private readonly artifacts: ArtifactsPort) {}
+
+  async getArtifact(hash: string): Promise<Result<JsonValue, string>> {
+    const result = await this.artifacts.getJson(hash);
+    if (!result.ok) return { ok: false, error: result.error.message };
+    return result;
+  }
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -5,3 +5,4 @@ export * from "./sim.service.js";
 export * from "./system.service.js";
 export * from "./run.service.js";
 export * from "./ws.service.js";
+export * from "./artifact.service.js";

--- a/packages/services/src/run.service.ts
+++ b/packages/services/src/run.service.ts
@@ -1,6 +1,5 @@
 import {
   EmitterFactoryPort,
-  EventBusPort,
   FlowIndexStorePort,
   RunIndexStorePort,
   RunRequest,
@@ -8,6 +7,7 @@ import {
 } from "@lcase/ports";
 import { createRunId, runFlow } from "@lcase/run-flow";
 import { listAllRuns } from "@lcase/run-history";
+import { Result, RunIndex } from "@lcase/types";
 
 export class RunService implements RunServicePort {
   constructor(
@@ -27,5 +27,11 @@ export class RunService implements RunServicePort {
   async listAllRuns() {
     const runList = await listAllRuns(this.runStore, this.flowStore);
     return runList;
+  }
+
+  async getRunIndex(runId: string): Promise<Result<RunIndex, string>> {
+    const runIndex = await this.runStore.getRunIndex(runId);
+    if (!runIndex) return { ok: false, error: "No run index found" };
+    return { ok: true, value: runIndex };
   }
 }

--- a/packages/types/src/api/artifacts/get-artifact.ts
+++ b/packages/types/src/api/artifacts/get-artifact.ts
@@ -1,0 +1,9 @@
+import { JsonValue } from "../../json-value.js";
+
+export type GetArtifactReq = { hash: string };
+export type GetArtifactRes =
+  | {
+      ok: true;
+      jsonValue: JsonValue;
+    }
+  | { ok: false; error: string };

--- a/packages/types/src/api/index.ts
+++ b/packages/types/src/api/index.ts
@@ -4,6 +4,8 @@ export * from "./flows/files/post-flow-file.js";
 export * from "./runs/post-runs.js";
 export * from "./runs/get-runs.js";
 export * from "./runs/get-run-events.js";
+export * from "./runs/get-run-index.js";
 export * from "./sims/get-sims.js";
 export * from "./sims/post-sims.js";
 export * from "./sims/get-sim.js";
+export * from "./artifacts/get-artifact.js";

--- a/packages/types/src/api/runs/get-run-index.ts
+++ b/packages/types/src/api/runs/get-run-index.ts
@@ -1,0 +1,9 @@
+import type { RunIndex } from "../../engine/run-index.js";
+
+export type GetRunIndexReq = { runId: string };
+export type GetRunIndexRes =
+  | {
+      ok: true;
+      index: RunIndex;
+    }
+  | { ok: false; error: string };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./result.type.js";
 export * from "./json-simple-value.js";
+export * from "./json-value.js";
 export * from "./events/shared/index.js";
 
 export * from "./events/flow/data.js";

--- a/packages/types/src/json-value.ts
+++ b/packages/types/src/json-value.ts
@@ -1,0 +1,7 @@
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [I in string]: JsonValue };


### PR DESCRIPTION
## Summary

Adding an artifact list and simple viewer to the run details tabs for historical runs, using a REST API.

Live runs could calculate this on the fly based on event outputs, but currently this data pulls from RunIndex for step outputs and the flow definition itself.

## Changes

- New artifact service to retrieve json artifacts exposed to the server.
- http-server `/api/artifacts/:hash` route to retrieve an artifact
- http-server `/api/runs/:runId` to get the run index for a run, which contains step output hashes.
- RTK query for these endpoints
- Artifact components in runs for listing artifacts and viewing one in tabs.
- Supporting types for requests / responses.