### PR TITLE
feat(artifacts): support multi-format CAS artifacts + sidecar indexes

### DIFF
--- a/apps/http-server/src/run-spec.ts
+++ b/apps/http-server/src/run-spec.ts
@@ -1,0 +1,89 @@
+/**
+ *
+ *
+ *
+ * Create a config / spec for runs.  These are user supplied args that affect
+ * runs.  different than a run plan.
+ *
+ * so for args like:
+ *
+ * {
+ *  llm-template: 1235351283051928752398 // hash
+ * }
+ *
+ * so eventually eventually a runspec will be like:
+ * run spec
+ * {
+ *    flowDefHash: string;
+ *    simSpecHash?: string;
+ *    runInput: {
+ *        prompt: "long literal string",
+ *        promptSaved: {{artifacts:12353102951240985723049875}}
+ *        promptSaved2: {{artifacts:Whatever the Name is.txt}}
+ *    }
+ * }
+ *
+ * RunInputs {
+ * }
+ *
+ * then in step definition:
+ *
+ *
+ * llm: {
+ *  type: "httpjson",
+ *  args: {
+ *    template: {{inputs.llm-template}}
+ *  }
+ * }
+ *
+ *
+ * inputs: {
+ *  llm-template: hash,
+ *  counter: string,
+ *  total: number,
+ * }
+ *
+ *
+ * i make a prompt file
+ * my prompt whatever
+ *
+ * artifact label / index
+ *
+ * prompt label /index
+ *
+ * {
+ *  label: string;
+ *  filename: string;
+ *  hash: string;
+ *  id: string;
+ * }
+ *
+ *
+ *
+ * simplest mvp:
+ *
+ * somehow add a runParamsIndex or runParams that is an artifact with hashes
+ *
+ * looks like:
+ *
+ * {
+ *    prompt: hash,
+ *    apiPrompt: hash,
+ * }
+ *
+ * add a way to add artifacts to the system through file upload
+ *
+ * prompt.md
+ * upload through file upload or json.
+ *
+ * get those hashes, create a runParamsIndex or whatever.
+ *
+ * worker gets runParamsIndex hash, opens it.
+ *
+ * then files the key, opens that hash.
+ *
+ * then traverses that if its necessary and a json object.
+ *
+ *
+ * problem:  ArtifactStore is currently json, not md.
+ */

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lcase/adapters",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "private": true,
   "type": "module",
   "exports": {
@@ -55,6 +55,9 @@
     "./fork-spec-index-store": {
       "types": "./dist/fork-spec-index-store/index.d.ts",
       "import": "./dist/fork-spec-index-store/index.js"
+    },
+    "./generic-store": {
+      "import": "./dist/generic-store/fs-json-index-store.js"
     }
   },
   "scripts": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -36,9 +36,17 @@
       "types": "./dist/artifact-store/index.d.ts",
       "import": "./dist/artifact-store/index.js"
     },
+    "./artifact-index-store": {
+      "types": "./dist/artifact-index-store/index.d.ts",
+      "import": "./dist/artifact-index-store/index.js"
+    },
     "./run-index-store": {
       "types": "./dist/run-index-store/index.d.ts",
       "import": "./dist/run-index-store/index.js"
+    },
+    "./run-params-index-store": {
+      "types": "./dist/run-params-index-store/index.d.ts",
+      "import": "./dist/run-params-index-store/index.js"
     },
     "./flow-index-store": {
       "types": "./dist/flow-index-store/index.d.ts",

--- a/packages/adapters/src/artifact-index-store/fs-artifact-index-store.ts
+++ b/packages/adapters/src/artifact-index-store/fs-artifact-index-store.ts
@@ -1,0 +1,109 @@
+import type { ArtifactIndexStorePort } from "@lcase/ports";
+import type { ArtifactIndex, Result } from "@lcase/types";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export class FsArtifactIndexStore implements ArtifactIndexStorePort {
+  baseDir: string;
+  rootPath: string;
+
+  constructor(rootPath: string) {
+    this.rootPath = rootPath;
+    this.baseDir = path.join(this.rootPath);
+  }
+
+  async init(): Promise<void> {
+    await fs.mkdir(this.baseDir, { recursive: true });
+  }
+
+  async put(index: ArtifactIndex): Promise<Result<ArtifactIndex, string>> {
+    try {
+      const json = JSON.stringify(index, null, 2);
+      const absoluteFilePath = this.getAbsoluteFilePath(index.hash);
+      await fs.mkdir(path.dirname(absoluteFilePath), { recursive: true });
+      await fs.writeFile(absoluteFilePath, json, { encoding: "utf8" });
+      return { ok: true, value: index };
+    } catch (e) {
+      return { ok: false, error: `Error writing artifact index: ${e}` };
+    }
+  }
+
+  async get(hash: string): Promise<ArtifactIndex | undefined> {
+    try {
+      const absoluteFilePath = this.getAbsoluteFilePath(hash);
+      const data = await fs.readFile(absoluteFilePath, { encoding: "utf8" });
+      return JSON.parse(data) as ArtifactIndex;
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  async getIndexList(): Promise<string[]> {
+    try {
+      const filePaths = await this.listIndexFiles(this.baseDir);
+      return filePaths
+        .map((filePath) => this.hashFromIndexPath(filePath))
+        .filter((hash): hash is string => Boolean(hash));
+    } catch (err) {
+      console.log(`Error reading directory ${this.baseDir}: ${err}`);
+      return [];
+    }
+  }
+
+  async getAll(): Promise<ArtifactIndex[]> {
+    try {
+      const indexes: ArtifactIndex[] = [];
+      const hashes = await this.getIndexList();
+      for (const hash of hashes) {
+        const index = await this.get(hash);
+        if (index) indexes.push(index);
+      }
+      return indexes;
+    } catch (err) {
+      console.log(`Error getting all files directory ${this.baseDir}: ${err}`);
+      return [];
+    }
+  }
+
+  private getAbsoluteFilePath(hash: string): string {
+    return path.join(this.getAbsoluteDirPath(hash), this.getFileName(hash));
+  }
+
+  private getFileName(hash: string): string {
+    return `${hash.slice(4)}.index.json`;
+  }
+
+  private getAbsoluteDirPath(hash: string): string {
+    const dirOne = hash.slice(0, 2);
+    const dirTwo = hash.slice(2, 4);
+    return path.join(this.baseDir, dirOne, dirTwo);
+  }
+
+  private async listIndexFiles(dir: string): Promise<string[]> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const files: string[] = [];
+
+    for (const entry of entries) {
+      const absolutePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...(await this.listIndexFiles(absolutePath)));
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".index.json")) {
+        files.push(absolutePath);
+      }
+    }
+
+    return files;
+  }
+
+  private hashFromIndexPath(filePath: string): string | null {
+    const relative = path.relative(this.baseDir, filePath);
+    const parts = relative.split(path.sep);
+    if (parts.length < 3) return null;
+    const [dirOne, dirTwo, fileName] = parts.slice(-3);
+    if (!fileName.endsWith(".index.json")) return null;
+    const base = fileName.slice(0, -".index.json".length);
+    return `${dirOne}${dirTwo}${base}`;
+  }
+}

--- a/packages/adapters/src/artifact-index-store/index.ts
+++ b/packages/adapters/src/artifact-index-store/index.ts
@@ -1,0 +1,1 @@
+export * from "./fs-artifact-index-store.js";

--- a/packages/adapters/src/artifact-store/fs-artifact-store.ts
+++ b/packages/adapters/src/artifact-store/fs-artifact-store.ts
@@ -18,7 +18,7 @@ export class FsArtifactStore implements ArtifactStorePort {
   }
   async putBytes(
     hash: string,
-    bytes: Uint8Array
+    bytes: Uint8Array,
   ): Promise<ArtifactStorePutResult> {
     const absoluteTempFilePath = this.getAbsoluteFilePath(hash, true);
     const absoluteFilePath = this.getAbsoluteFilePath(hash);
@@ -65,7 +65,7 @@ export class FsArtifactStore implements ArtifactStorePort {
   getAbsoluteFilePath(hash: string, tmp: boolean = false): string {
     return path.join(
       this.getAbsoluteDirPath(hash),
-      this.getFileName(hash, tmp)
+      this.getFileName(hash, tmp),
     );
   }
 

--- a/packages/adapters/src/generic-store/fs-json-index-store.ts
+++ b/packages/adapters/src/generic-store/fs-json-index-store.ts
@@ -1,0 +1,109 @@
+import type { Result } from "@lcase/types";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type FsJsonIndexStoreOptions<T> = {
+  dir: string;
+  extension?: string;
+  encoding?: BufferEncoding;
+  sort?: (a: T, b: T) => number;
+};
+
+export class FsJsonIndexStore<T> {
+  private dir: string;
+  private extension: string;
+  private encoding: BufferEncoding;
+  private sort?: (a: T, b: T) => number;
+
+  constructor(options: FsJsonIndexStoreOptions<T>) {
+    const { dir } = options;
+    if (!path.isAbsolute(dir) || path.extname(dir) !== "") {
+      throw new Error(
+        `[fs-json-index-store] path must point to an absolute directory: ${dir}`,
+      );
+    }
+
+    this.dir = dir;
+    this.extension = options.extension ?? ".index.json";
+    if (!this.extension.startsWith(".")) {
+      this.extension = `.${this.extension}`;
+    }
+    this.encoding = options.encoding ?? "utf8";
+    this.sort = options.sort;
+  }
+
+  async init(): Promise<void> {
+    try {
+      await fs.access(this.dir);
+    } catch (e) {
+      try {
+        await fs.mkdir(this.dir, { recursive: true });
+        return;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Cannot create directory.";
+        throw new Error(`[fs-json-index-store] ${message}`);
+      }
+    }
+  }
+
+  async put(id: string, value: T): Promise<Result<string, string>> {
+    try {
+      const json = JSON.stringify(value, null, 2);
+      const fullPath = path.join(this.dir, this.fileName(id));
+      await fs.writeFile(fullPath, json, { encoding: this.encoding });
+      return { ok: true, value: fullPath };
+    } catch (e) {
+      return { ok: false, error: `Error writing index: ${e}` };
+    }
+  }
+
+  async get(id: string): Promise<T | undefined> {
+    try {
+      const absoluteFilePath = path.join(this.dir, this.fileName(id));
+      const data = await fs.readFile(absoluteFilePath, { encoding: this.encoding });
+      return JSON.parse(data) as T;
+    } catch (e) {
+      console.log(`Error reading index for id:${id}. ${e}`);
+    }
+  }
+
+  async getIdList(): Promise<string[]> {
+    try {
+      const files = await fs.readdir(this.dir);
+      if (!files || files.length === 0) return [];
+
+      const fileNames: string[] = [];
+      for (const file of files) {
+        if (!file.endsWith(this.extension)) continue;
+        fileNames.push(file.slice(0, -this.extension.length));
+      }
+      return fileNames;
+    } catch (err) {
+      console.log(`Error reading directory ${this.dir}: ${err}`);
+      return [];
+    }
+  }
+
+  async getAll(): Promise<T[]> {
+    try {
+      const items: T[] = [];
+      const ids = await this.getIdList();
+
+      for (const id of ids) {
+        const item = await this.get(id);
+        if (item) items.push(item);
+      }
+
+      if (this.sort) items.sort(this.sort);
+      return items;
+    } catch (err) {
+      console.log(`Error getting all files directory ${this.dir}: ${err}`);
+      return [];
+    }
+  }
+
+  private fileName(id: string): string {
+    return `${id}${this.extension}`;
+  }
+}

--- a/packages/adapters/src/index-store/fs-json-index-store.ts
+++ b/packages/adapters/src/index-store/fs-json-index-store.ts
@@ -1,21 +1,15 @@
-import type { Result } from "@lcase/types";
+import type { AnyIndex, IndexStorePort } from "@lcase/ports";
+import type { Result, FsJsonIndexStoreOptions } from "@lcase/types";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-export type FsJsonIndexStoreOptions<T> = {
-  dir: string;
-  extension?: string;
-  encoding?: BufferEncoding;
-  sort?: (a: T, b: T) => number;
-};
-
-export class FsJsonIndexStore<T> {
+export class FsJsonIndexStore<I extends AnyIndex> implements IndexStorePort<I> {
   private dir: string;
   private extension: string;
   private encoding: BufferEncoding;
-  private sort?: (a: T, b: T) => number;
+  private sort?: (a: I, b: I) => number;
 
-  constructor(options: FsJsonIndexStoreOptions<T>) {
+  constructor(options: FsJsonIndexStoreOptions<I>) {
     const { dir } = options;
     if (!path.isAbsolute(dir) || path.extname(dir) !== "") {
       throw new Error(
@@ -25,6 +19,7 @@ export class FsJsonIndexStore<T> {
 
     this.dir = dir;
     this.extension = options.extension ?? ".index.json";
+
     if (!this.extension.startsWith(".")) {
       this.extension = `.${this.extension}`;
     }
@@ -47,7 +42,7 @@ export class FsJsonIndexStore<T> {
     }
   }
 
-  async put(id: string, value: T): Promise<Result<string, string>> {
+  async put(id: string, value: I): Promise<Result<string, string>> {
     try {
       const json = JSON.stringify(value, null, 2);
       const fullPath = path.join(this.dir, this.fileName(id));
@@ -58,11 +53,13 @@ export class FsJsonIndexStore<T> {
     }
   }
 
-  async get(id: string): Promise<T | undefined> {
+  async get(id: string): Promise<I | undefined> {
     try {
       const absoluteFilePath = path.join(this.dir, this.fileName(id));
-      const data = await fs.readFile(absoluteFilePath, { encoding: this.encoding });
-      return JSON.parse(data) as T;
+      const data = await fs.readFile(absoluteFilePath, {
+        encoding: this.encoding,
+      });
+      return JSON.parse(data) as I;
     } catch (e) {
       console.log(`Error reading index for id:${id}. ${e}`);
     }
@@ -85,9 +82,9 @@ export class FsJsonIndexStore<T> {
     }
   }
 
-  async getAll(): Promise<T[]> {
+  async getAll(): Promise<I[]> {
     try {
-      const items: T[] = [];
+      const items: I[] = [];
       const ids = await this.getIdList();
 
       for (const id of ids) {

--- a/packages/adapters/src/run-params-index-store/fs-run-params-index-store.ts
+++ b/packages/adapters/src/run-params-index-store/fs-run-params-index-store.ts
@@ -1,0 +1,36 @@
+import type { RunParamsIndexStorePort } from "@lcase/ports";
+import type { Result, RunParams } from "@lcase/types";
+import { FsJsonIndexStore } from "../generic-store/fs-json-index-store.js";
+
+export class FsRunParamsIndexStore implements RunParamsIndexStorePort {
+  private store: FsJsonIndexStore<RunParams>;
+
+  constructor(
+    dir: string,
+    store: FsJsonIndexStore<RunParams> = new FsJsonIndexStore<RunParams>({
+      dir,
+      extension: ".index.json",
+    }),
+  ) {
+    this.store = store;
+  }
+
+  async init(): Promise<void> {
+    await this.store.init();
+  }
+
+  async putRunParams(
+    runId: string,
+    params: RunParams,
+  ): Promise<Result<string, string>> {
+    return this.store.put(runId, params);
+  }
+
+  async getRunParams(runId: string): Promise<RunParams | undefined> {
+    return this.store.get(runId);
+  }
+
+  async getAllRunIds(): Promise<string[]> {
+    return this.store.getIdList();
+  }
+}

--- a/packages/adapters/src/run-params-index-store/fs-run-params-index-store.ts
+++ b/packages/adapters/src/run-params-index-store/fs-run-params-index-store.ts
@@ -1,36 +1,36 @@
-import type { RunParamsIndexStorePort } from "@lcase/ports";
-import type { Result, RunParams } from "@lcase/types";
-import { FsJsonIndexStore } from "../generic-store/fs-json-index-store.js";
+// import type { RunParamsIndexStorePort } from "@lcase/ports";
+// import type { Result, RunParams } from "@lcase/types";
+// import { FsJsonIndexStore } from "../generic-store/fs-json-index-store.js";
 
-export class FsRunParamsIndexStore implements RunParamsIndexStorePort {
-  private store: FsJsonIndexStore<RunParams>;
+// export class FsRunParamsIndexStore implements RunParamsIndexStorePort {
+//   private store: FsJsonIndexStore<RunParams>;
 
-  constructor(
-    dir: string,
-    store: FsJsonIndexStore<RunParams> = new FsJsonIndexStore<RunParams>({
-      dir,
-      extension: ".index.json",
-    }),
-  ) {
-    this.store = store;
-  }
+//   constructor(
+//     dir: string,
+//     store: FsJsonIndexStore<RunParams> = new FsJsonIndexStore<RunParams>({
+//       dir,
+//       extension: ".index.json",
+//     }),
+//   ) {
+//     this.store = store;
+//   }
 
-  async init(): Promise<void> {
-    await this.store.init();
-  }
+//   async init(): Promise<void> {
+//     await this.store.init();
+//   }
 
-  async putRunParams(
-    runId: string,
-    params: RunParams,
-  ): Promise<Result<string, string>> {
-    return this.store.put(runId, params);
-  }
+//   async putRunParams(
+//     runId: string,
+//     params: RunParams,
+//   ): Promise<Result<string, string>> {
+//     return this.store.put(runId, params);
+//   }
 
-  async getRunParams(runId: string): Promise<RunParams | undefined> {
-    return this.store.get(runId);
-  }
+//   async getRunParams(runId: string): Promise<RunParams | undefined> {
+//     return this.store.get(runId);
+//   }
 
-  async getAllRunIds(): Promise<string[]> {
-    return this.store.getIdList();
-  }
-}
+//   async getAllRunIds(): Promise<string[]> {
+//     return this.store.getIdList();
+//   }
+// }

--- a/packages/adapters/src/run-params-index-store/index.ts
+++ b/packages/adapters/src/run-params-index-store/index.ts
@@ -1,1 +1,1 @@
-export * from "./fs-run-params-index-store.js";
+// export * from "./fs-run-params-index-store.js";

--- a/packages/adapters/src/run-params-index-store/index.ts
+++ b/packages/adapters/src/run-params-index-store/index.ts
@@ -1,0 +1,1 @@
+export * from "./fs-run-params-index-store.js";

--- a/packages/adapters/tests/index-store/fs-flow-index-store.test.ts
+++ b/packages/adapters/tests/index-store/fs-flow-index-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { FsJsonIndexStore } from "../../src/index-store/fs-json-index-store.js";
 import { FsFlowIndexStore } from "../../src/flow-index-store/flow-index-store.js";
 import type { FlowIndex, RunIndex } from "@lcase/types";
 import path from "node:path";
@@ -7,14 +8,14 @@ describe("FsFlowIndexStore", () => {
   it("putFlowIndex() writes the correct index to the correct path", async () => {
     const dirPath = import.meta.dirname;
     const hash = "test-hash";
-    const store = new FsFlowIndexStore(dirPath);
+    const store = new FsJsonIndexStore<FlowIndex>({ dir: dirPath });
     const index: FlowIndex = {
       hash,
       name: "test-name",
       version: "test-version",
       description: "test-description",
     };
-    await store.putFlowIndex(index);
+    await store.put(hash, index);
     const expectedFilePath = path.join(dirPath, `${hash}.index.json`);
     const data = fs.readFileSync(expectedFilePath, {
       encoding: "utf8",
@@ -30,8 +31,8 @@ describe("FsFlowIndexStore", () => {
     );
     const hash = "test-hash";
 
-    const store = new FsFlowIndexStore(dirPath);
-    const result = await store.getFlowIndex(hash);
+    const store = new FsJsonIndexStore<FlowIndex>({ dir: dirPath });
+    const result = await store.get(hash);
     const expectedIndex: FlowIndex = {
       hash,
       name: "test-name",
@@ -39,6 +40,6 @@ describe("FsFlowIndexStore", () => {
       description: "test-description",
     };
 
-    expect(result).toEqual({ ok: true, value: expectedIndex });
+    expect(result).toEqual(expectedIndex);
   });
 });

--- a/packages/adapters/tests/index-store/fs-run-index-store.test.ts
+++ b/packages/adapters/tests/index-store/fs-run-index-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { FsRunIndexStore } from "../../src/run-index-store/fs-run-index-store.js";
+import { describe, it, expect } from "vitest";
+import { FsJsonIndexStore } from "../../src/index-store/fs-json-index-store.js";
 import type { RunIndex } from "@lcase/types";
 import path from "node:path";
 import fs from "node:fs";
@@ -7,7 +7,7 @@ describe("FsRunIndexStore", () => {
   it("putRunIndex() writes the correct index to the correct path", async () => {
     const dirPath = import.meta.dirname;
     const runId = "run-242b4e22-d5aa-44fc-bec2-f745eb96f605";
-    const store = new FsRunIndexStore(dirPath);
+    const store = new FsJsonIndexStore<RunIndex>({ dir: dirPath });
     const index: RunIndex = {
       flowId: "933dcae021a90ab5df5a5b1b47b590bd",
       steps: {
@@ -33,7 +33,7 @@ describe("FsRunIndexStore", () => {
       endTime: "2026-01-23T00:01:38.984Z",
       duration: 30.356,
     };
-    await store.putRunIndex(index, runId);
+    await store.put(runId, index);
     const expectedFilePath = path.join(dirPath, `${runId}.index.json`);
     const data = fs.readFileSync(expectedFilePath, {
       encoding: "utf8",
@@ -48,8 +48,8 @@ describe("FsRunIndexStore", () => {
       "../fixtures/run-index-store",
     );
     const runId = "run-242b4e22-d5aa-44fc-bec2-f745eb96f605";
-    const store = new FsRunIndexStore(dirPath);
-    const index = await store.getRunIndex(runId);
+    const store = new FsJsonIndexStore<RunIndex>({ dir: dirPath });
+    const index = await store.get(runId);
     const expectedIndex: RunIndex = {
       flowId: "933dcae021a90ab5df5a5b1b47b590bd",
       steps: {

--- a/packages/artifacts/src/artifacts.ts
+++ b/packages/artifacts/src/artifacts.ts
@@ -1,40 +1,131 @@
 import type {
   ArtifactsPort,
+  ArtifactIndexInput,
   ArtifactStorePort,
+  AutoGetResult,
   GetError,
   JsonValue,
   PutError,
 } from "@lcase/ports";
+import type { ArtifactIndexStorePort } from "@lcase/ports";
 import { Result } from "@lcase/types";
 import { createHash } from "node:crypto";
 
 export class Artifacts implements ArtifactsPort {
   encoder: TextEncoder;
   decoder: TextDecoder;
-  constructor(private readonly store: ArtifactStorePort) {
+  constructor(
+    private readonly store: ArtifactStorePort,
+    private readonly indexStore?: ArtifactIndexStorePort,
+  ) {
     this.encoder = new TextEncoder();
     this.decoder = new TextDecoder();
   }
-  async putJson(value: JsonValue): Promise<Result<string, PutError>> {
+
+  // typed overloads for a simplified callsite implementation
+  async put(
+    value: JsonValue,
+    opts: { format: "json"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+  async put(
+    value: string,
+    opts: { format: "text"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+  async put(
+    value: string,
+    opts: { format: "markdown"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+  async put(
+    value: Uint8Array,
+    opts: { format: "bytes"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+  async put(
+    value: JsonValue | string | Uint8Array,
+    opts: {
+      format: "json" | "text" | "markdown" | "bytes";
+      index?: ArtifactIndexInput;
+    },
+  ): Promise<Result<string, PutError>> {
+    switch (opts.format) {
+      case "json":
+        return this.putJson(value as JsonValue, opts.index);
+      case "text":
+        return this.putText(value as string, opts.index);
+      case "markdown":
+        return this.putMarkdown(value as string, opts.index);
+      case "bytes":
+        return this.putBytes(value as Uint8Array, opts.index);
+    }
+  }
+
+  async get(
+    hash: string,
+    opts: { format: "json" },
+  ): Promise<Result<JsonValue, GetError>>;
+  async get(
+    hash: string,
+    opts: { format: "text" },
+  ): Promise<Result<string, GetError>>;
+  async get(
+    hash: string,
+    opts: { format: "markdown" },
+  ): Promise<Result<string, GetError>>;
+  async get(
+    hash: string,
+    opts: { format: "bytes" },
+  ): Promise<Result<Uint8Array, GetError>>;
+  async get(
+    hash: string,
+    opts: { format: "json" | "text" | "markdown" | "bytes" },
+  ): Promise<Result<JsonValue | string | Uint8Array, GetError>> {
+    switch (opts.format) {
+      case "json":
+        return this.getJson(hash);
+      case "text":
+        return this.getText(hash);
+      case "markdown":
+        return this.getMarkdown(hash);
+      case "bytes":
+        return this.getBytes(hash);
+    }
+  }
+
+  async getAuto(hash: string): Promise<AutoGetResult> {
+    const index = await this.indexStore?.get(hash);
+    const format = this.inferFormat(index?.format, index?.contentType);
+
+    switch (format) {
+      case "json": {
+        const result = await this.getJson(hash);
+        if (!result.ok) return { ok: false, error: result.error };
+        return { ok: true, format: "json", value: result.value };
+      }
+      case "markdown": {
+        const result = await this.getMarkdown(hash);
+        if (!result.ok) return { ok: false, error: result.error };
+        return { ok: true, format: "markdown", value: result.value };
+      }
+      case "text": {
+        const result = await this.getText(hash);
+        if (!result.ok) return { ok: false, error: result.error };
+        return { ok: true, format: "text", value: result.value };
+      }
+      default: {
+        const result = await this.getBytes(hash);
+        if (!result.ok) return { ok: false, error: result.error };
+        return { ok: true, format: "bytes", value: result.value };
+      }
+    }
+  }
+  async putJson(
+    value: JsonValue,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>> {
     try {
       const sortedJsonValue = this.sortJson(value);
       const json = JSON.stringify(sortedJsonValue);
       const bytes = this.encoder.encode(json);
-      const hash = this.hashBytes(bytes);
-      const result = await this.store.putBytes(hash, bytes);
-
-      if (!result.ok) {
-        return {
-          ok: false,
-          error: {
-            code: "STORE_PUT_FAILED",
-            message: "Error putting bytes in store",
-            cause: result.cause,
-          },
-        };
-      }
-
-      return { ok: true, value: hash };
+      return await this.putBytesInternal(bytes, index, "json");
     } catch (e) {
       return {
         ok: false,
@@ -71,6 +162,163 @@ export class Artifacts implements ArtifactsPort {
         },
       };
     }
+  }
+
+  async putText(
+    value: string,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>> {
+    try {
+      const bytes = this.encoder.encode(value);
+      return await this.putBytesInternal(bytes, index, "text");
+    } catch (e) {
+      return {
+        ok: false,
+        error: {
+          code: "UNKNOWN",
+          message: "Error putting text",
+          cause: e instanceof Error ? e.message : String(e),
+        },
+      };
+    }
+  }
+
+  async putMarkdown(
+    value: string,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>> {
+    try {
+      const bytes = this.encoder.encode(value);
+      return await this.putBytesInternal(bytes, index, "markdown");
+    } catch (e) {
+      return {
+        ok: false,
+        error: {
+          code: "UNKNOWN",
+          message: "Error putting markdown",
+          cause: e instanceof Error ? e.message : String(e),
+        },
+      };
+    }
+  }
+
+  async getText(hash: string): Promise<Result<string, GetError>> {
+    const bytesResult = await this.getBytes(hash);
+    if (!bytesResult.ok) return { ok: false, error: bytesResult.error };
+    return { ok: true, value: this.decoder.decode(bytesResult.value) };
+  }
+
+  async getMarkdown(hash: string): Promise<Result<string, GetError>> {
+    return this.getText(hash);
+  }
+
+  async putBytes(
+    bytes: Uint8Array,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>> {
+    return this.putBytesInternal(bytes, index, "bytes");
+  }
+
+  private async putBytesInternal(
+    bytes: Uint8Array,
+    index: ArtifactIndexInput | undefined,
+    format: "json" | "text" | "markdown" | "bytes",
+  ): Promise<Result<string, PutError>> {
+    try {
+      const hash = this.hashBytes(bytes);
+      const result = await this.store.putBytes(hash, bytes);
+
+      if (!result.ok) {
+        return {
+          ok: false,
+          error: {
+            code: "STORE_PUT_FAILED",
+            message: "Error putting bytes in store",
+            cause: result.cause,
+          },
+        };
+      }
+
+      const indexResult = await this.putIndex(hash, index, bytes.length, format);
+      if (!indexResult.ok) return indexResult;
+
+      return { ok: true, value: hash };
+    } catch (e) {
+      return {
+        ok: false,
+        error: {
+          code: "UNKNOWN",
+          message: "Error putting bytes",
+          cause: e instanceof Error ? e.message : String(e),
+        },
+      };
+    }
+  }
+
+  async getBytes(hash: string): Promise<Result<Uint8Array, GetError>> {
+    const bytes = await this.store.getBytes(hash);
+    if (bytes === null)
+      return {
+        ok: false,
+        error: {
+          code: "STORE_GET_FAILED",
+          message: "Store returned null",
+        },
+      };
+    return { ok: true, value: bytes };
+  }
+
+  private async putIndex(
+    hash: string,
+    index: ArtifactIndexInput | undefined,
+    size: number,
+    format: "json" | "text" | "markdown" | "bytes",
+  ): Promise<Result<string, PutError>> {
+    if (!this.indexStore) return { ok: true, value: hash };
+
+    const defaultContentType =
+      format === "json"
+        ? "application/json"
+        : format === "markdown"
+          ? "text/markdown"
+          : format === "text"
+            ? "text/plain"
+            : "application/octet-stream";
+
+    const indexResult = await this.indexStore.put({
+      time: index?.time ?? new Date().toISOString(),
+      size,
+      contentType: defaultContentType,
+      format,
+      ...(index ?? {}),
+      hash,
+    });
+
+    if (!indexResult.ok) {
+      return {
+        ok: false,
+        error: {
+          code: "INDEX_PUT_FAILED",
+          message: "Error putting artifact index",
+          cause: indexResult.error,
+          details: { hash },
+        },
+      };
+    }
+
+    return { ok: true, value: hash };
+  }
+
+  private inferFormat(
+    format: "json" | "text" | "markdown" | "bytes" | undefined,
+    contentType: string | undefined,
+  ): "json" | "text" | "markdown" | "bytes" {
+    if (format) return format;
+    if (!contentType) return "bytes";
+    if (contentType === "application/json") return "json";
+    if (contentType === "text/markdown") return "markdown";
+    if (contentType.startsWith("text/")) return "text";
+    return "bytes";
   }
 
   hashBytes(bytes: Uint8Array): string {

--- a/packages/controller/src/fork-spec.controller.ts
+++ b/packages/controller/src/fork-spec.controller.ts
@@ -1,17 +1,17 @@
 import type {
   ArtifactsPort,
   EmitterFactoryPort,
-  EventBusPort,
-  RunIndexStorePort,
+  IndexStorePort,
 } from "@lcase/ports";
 import { startForkedSim } from "@lcase/run-flow";
 import { getRunFlowHash } from "@lcase/run-history";
+import { RunIndex } from "@lcase/types";
 
 export class ForkSpecController {
   constructor(
     private readonly artifacts: ArtifactsPort,
     private readonly ef: EmitterFactoryPort,
-    private readonly runIndexStore: RunIndexStorePort,
+    private readonly runIndexStore: IndexStorePort<RunIndex>,
   ) {}
 
   async runForkedSim(

--- a/packages/engine/src/effects/get-run-index.effect.ts
+++ b/packages/engine/src/effects/get-run-index.effect.ts
@@ -6,7 +6,7 @@ export const getRunIndexFx: EffectHandler<"GetRunIndex"> = async (
   effect: GetRunIndexFx,
   deps: EffectHandlerDeps,
 ) => {
-  const index = await deps.runIndexStore.getRunIndex(effect.parentRunId);
+  const index = await deps.runIndexStore.get(effect.parentRunId);
 
   if (index) {
     const message: RunIndexResultMsg = {

--- a/packages/engine/src/engine.types.ts
+++ b/packages/engine/src/engine.types.ts
@@ -1,6 +1,7 @@
 import type {
   ArtifactsPort,
   EmitterFactoryPort,
+  IndexStorePort,
   RunIndexStorePort,
 } from "@lcase/ports";
 import type {
@@ -18,6 +19,7 @@ import type {
   JobScope,
   RunCompletedData,
   RunFailedData,
+  RunIndex,
   RunScope,
   RunStartedData,
   StepCompletedData,
@@ -302,7 +304,7 @@ export type EffectHandlerRegistry = {
 };
 export type EffectHandlerDeps = {
   ef: EmitterFactoryPort;
-  runIndexStore: RunIndexStorePort;
+  runIndexStore: IndexStorePort<RunIndex>;
   enqueue: (message: EngineMessage) => void;
   processAll: () => void;
   artifacts: ArtifactsPort;

--- a/packages/engine/tests/effects/get-run-index.effect.test.ts
+++ b/packages/engine/tests/effects/get-run-index.effect.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ArtifactsPort, RunIndexStorePort } from "@lcase/ports";
+import type {
+  ArtifactsPort,
+  IndexStorePort,
+  RunIndexStorePort,
+} from "@lcase/ports";
 import type { EffectHandlerDeps } from "../../src/engine.types.js";
 import { getRunIndexFx } from "../../src/effects/get-run-index.effect.js";
 import { GetForkSpecFx, GetRunIndexFx } from "../../src/types/effect.types.js";
@@ -7,7 +11,7 @@ import {
   ForkSpecResultMsg,
   RunIndexResultMsg,
 } from "../../src/types/message.types.js";
-import { ForkSpec } from "@lcase/types";
+import { ForkSpec, RunIndex } from "@lcase/types";
 
 const forkSpec: ForkSpec = {
   parentRunId: "test-parentrunid",
@@ -27,13 +31,13 @@ describe("getRunIndexFx()", () => {
       type: "RunIndexResult",
     };
     const returnValue = { ok: true, value: message.runIndex };
-    const getRunIndex = vi.fn().mockResolvedValue(message.runIndex);
+    const get = vi.fn().mockResolvedValue(message.runIndex);
     const enqueue = vi.fn().mockReturnValue(undefined) as (
       message: string,
     ) => void;
     const processAll = vi.fn().mockReturnValue(undefined) as () => void;
 
-    const runIndexStore = { getRunIndex } as unknown as RunIndexStorePort;
+    const runIndexStore = { get } as unknown as IndexStorePort<RunIndex>;
 
     const effect: GetRunIndexFx = {
       type: "GetRunIndex",
@@ -47,7 +51,7 @@ describe("getRunIndexFx()", () => {
       processAll,
     } as unknown as EffectHandlerDeps);
 
-    expect(getRunIndex).toHaveBeenCalledExactlyOnceWith("test-parentrunid");
+    expect(get).toHaveBeenCalledExactlyOnceWith("test-parentrunid");
     expect(enqueue).toHaveBeenCalledExactlyOnceWith(message);
   });
   it("parses and enqueues the an error message given an invalid run index store result", async () => {
@@ -58,13 +62,13 @@ describe("getRunIndexFx()", () => {
       error: "Error getting run index for parentRunId: test-parentrunid",
     };
 
-    const getRunIndex = vi.fn().mockResolvedValue(undefined);
+    const get = vi.fn().mockResolvedValue(undefined);
     const enqueue = vi.fn().mockReturnValue(undefined) as (
       message: string,
     ) => void;
     const processAll = vi.fn().mockReturnValue(undefined) as () => void;
 
-    const runIndexStore = { getRunIndex } as unknown as RunIndexStorePort;
+    const runIndexStore = { get } as unknown as IndexStorePort<RunIndex>;
 
     const effect: GetRunIndexFx = {
       type: "GetRunIndex",
@@ -78,7 +82,7 @@ describe("getRunIndexFx()", () => {
       processAll,
     } as unknown as EffectHandlerDeps);
 
-    expect(getRunIndex).toHaveBeenCalledExactlyOnceWith("test-parentrunid");
+    expect(get).toHaveBeenCalledExactlyOnceWith("test-parentrunid");
     expect(enqueue).toHaveBeenCalledExactlyOnceWith(message);
   });
 });

--- a/packages/flow-analysis/src/parse-references.ts
+++ b/packages/flow-analysis/src/parse-references.ts
@@ -43,7 +43,7 @@ export function parseRef(
       stepId,
       bindPath,
       string: matchedString,
-      interpolated: false,
+      interpolated: isInterpolated(matches.length, value),
       hash: null,
     };
     if (matchedScope === "steps") {
@@ -105,4 +105,10 @@ export function parseArray(part: string): { key?: string; index?: string[] } {
   if (!match) return {};
 
   return { key: match[0], index: match.slice(1) };
+}
+
+export function isInterpolated(matches: number, value: string) {
+  if (matches >= 2) return false;
+  if (value.startsWith("{{") && value.endsWith("}}")) return false;
+  return true;
 }

--- a/packages/json-ref-binder/src/bind.ts
+++ b/packages/json-ref-binder/src/bind.ts
@@ -81,11 +81,13 @@ export function bindReference(
  * @returns unknown value
  */
 export function interpolateRef(field: unknown, value: unknown, ref: Ref) {
+  console.log("called interpolate:", ref.string);
   if (ref.interpolated && typeof field === "string") {
     const stringified =
       typeof value === "object" || Array.isArray(value)
         ? util.inspect(value, false, null)
         : String(value);
+
     return field.replaceAll(`{{${ref.string}}}`, stringified);
   } else return value;
 }

--- a/packages/ports/src/artifact-index-store/artifact-index-store.port.ts
+++ b/packages/ports/src/artifact-index-store/artifact-index-store.port.ts
@@ -1,0 +1,9 @@
+import type { ArtifactIndex, Result } from "@lcase/types";
+
+export interface ArtifactIndexStorePort {
+  init(): Promise<void>;
+  put(index: ArtifactIndex): Promise<Result<ArtifactIndex, string>>;
+  get(hash: string): Promise<ArtifactIndex | undefined>;
+  getIndexList(): Promise<string[]>;
+  getAll(): Promise<ArtifactIndex[]>;
+}

--- a/packages/ports/src/artifacts/artifacts.port.ts
+++ b/packages/ports/src/artifacts/artifacts.port.ts
@@ -1,3 +1,4 @@
+import type { ArtifactIndex } from "@lcase/types";
 import { Result } from "@lcase/types";
 
 export type JsonValue =
@@ -14,7 +15,7 @@ export type PutResponse = {
 };
 
 export type PutError = {
-  code: "UNKNOWN" | "STORE_PUT_FAILED";
+  code: "UNKNOWN" | "STORE_PUT_FAILED" | "INDEX_PUT_FAILED";
   message: string;
   cause?: string;
   details?: Record<string, string>;
@@ -26,7 +27,72 @@ export type GetError = {
   cause?: string;
   details?: Record<string, string>;
 };
+
+export type AutoGetResult =
+  | { ok: true; format: "json"; value: JsonValue }
+  | { ok: true; format: "text" | "markdown"; value: string }
+  | { ok: true; format: "bytes"; value: Uint8Array }
+  | { ok: false; error: GetError };
+
+export type ArtifactIndexInput = Partial<Omit<ArtifactIndex, "hash" | "time">> & {
+  time?: string;
+};
+
 export interface ArtifactsPort {
-  putJson(value: JsonValue): Promise<Result<string, PutError>>;
+  put(
+    value: JsonValue,
+    opts: { format: "json"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+  put(
+    value: string,
+    opts: { format: "text"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+  put(
+    value: string,
+    opts: { format: "markdown"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+  put(
+    value: Uint8Array,
+    opts: { format: "bytes"; index?: ArtifactIndexInput },
+  ): Promise<Result<string, PutError>>;
+
+  get(
+    hash: string,
+    opts: { format: "json" },
+  ): Promise<Result<JsonValue, GetError>>;
+  get(
+    hash: string,
+    opts: { format: "text" },
+  ): Promise<Result<string, GetError>>;
+  get(
+    hash: string,
+    opts: { format: "markdown" },
+  ): Promise<Result<string, GetError>>;
+  get(
+    hash: string,
+    opts: { format: "bytes" },
+  ): Promise<Result<Uint8Array, GetError>>;
+
+  getAuto(hash: string): Promise<AutoGetResult>;
+
+  putJson(
+    value: JsonValue,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>>;
   getJson(hash: string): Promise<Result<JsonValue, GetError>>;
+  putText(
+    value: string,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>>;
+  putMarkdown(
+    value: string,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>>;
+  getText(hash: string): Promise<Result<string, GetError>>;
+  getMarkdown(hash: string): Promise<Result<string, GetError>>;
+  putBytes(
+    bytes: Uint8Array,
+    index?: ArtifactIndexInput,
+  ): Promise<Result<string, PutError>>;
+  getBytes(hash: string): Promise<Result<Uint8Array, GetError>>;
 }

--- a/packages/ports/src/engine/engine.port.ts
+++ b/packages/ports/src/engine/engine.port.ts
@@ -1,14 +1,15 @@
+import { RunIndex } from "@lcase/types";
 import { ArtifactsPort } from "../artifacts/artifacts.port.js";
 import { EventBusPort } from "../bus/event-bus.port.js";
 import { EmitterFactoryPort } from "../events/emitter-factory.port.js";
 import { JobParserPort } from "../events/job-parser.port.js";
-import { RunIndexStorePort } from "../run-index-store/run-index-store.port.js";
+import { IndexStorePort } from "../index-store/index-store.port.js";
 
 export type EngineDeps = {
   bus: EventBusPort;
   ef: EmitterFactoryPort;
   // flowParser: FlowParserPort;
   jobParser: JobParserPort;
-  runIndexStore: RunIndexStorePort;
+  runIndexStore: IndexStorePort<RunIndex>;
   artifacts: ArtifactsPort;
 };

--- a/packages/ports/src/index-store/index-store.port.ts
+++ b/packages/ports/src/index-store/index-store.port.ts
@@ -1,0 +1,18 @@
+import type {
+  ArtifactIndex,
+  FlowIndex,
+  ForkSpecIndex,
+  Result,
+  RunIndex,
+} from "@lcase/types";
+
+// data structures of the json index files
+export type AnyIndex = ForkSpecIndex | FlowIndex | ArtifactIndex | RunIndex;
+
+export interface IndexStorePort<Index extends AnyIndex> {
+  init(): Promise<void>;
+  put(id: string, value: Index): Promise<Result<string, string>>;
+  get(id: string): Promise<Index | undefined>;
+  getIdList(): Promise<string[]>;
+  getAll(): Promise<Index[]>;
+}

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -31,3 +31,6 @@ export * from "./worker/worker.port.js";
 export * from "./services/services.port.js";
 export * from "./flow-index-store/flow-index-store.js";
 export * from "./client-api/client-api.js";
+
+// index store (json)
+export * from "./index-store/index-store.port.js";

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -22,6 +22,8 @@ export * from "./limiter/limiter.port.js";
 export * from "./artifacts/artifact-store.port.js";
 export * from "./artifacts/artifacts.port.js";
 export * from "./run-index-store/run-index-store.port.js";
+export * from "./run-params-index-store/run-params-index-store.port.js";
+export * from "./artifact-index-store/artifact-index-store.port.js";
 export * from "./fork-spec-index-store/fork-spec-index-store.js";
 
 export * from "./worker/worker.port.js";

--- a/packages/ports/src/run-params-index-store/run-params-index-store.port.ts
+++ b/packages/ports/src/run-params-index-store/run-params-index-store.port.ts
@@ -1,0 +1,8 @@
+import type { RunParams, Result } from "@lcase/types";
+
+export interface RunParamsIndexStorePort {
+  init(): Promise<void>;
+  putRunParams(runId: string, params: RunParams): Promise<Result<string, string>>;
+  getRunParams(runId: string): Promise<RunParams | undefined>;
+  getAllRunIds(): Promise<string[]>;
+}

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -7,6 +7,7 @@ import type {
   Result,
   RunIndex,
   RunListItem,
+  RunParams,
 } from "@lcase/types";
 import type { EventSink } from "../observability/observability-sink.port.js";
 import type { RuntimeStatus } from "../controller.port.js";
@@ -78,6 +79,7 @@ export interface RunServicePort {
   makeRunId(): string;
   listAllRuns(): Promise<RunListItem[]>;
   getRunIndex(runId: string): Promise<Result<RunIndex, string>>;
+  getRunParamsIndex(runId: string): Promise<Result<RunParams, string>>;
 }
 
 export interface WsServicePort {

--- a/packages/ports/src/services/services.port.ts
+++ b/packages/ports/src/services/services.port.ts
@@ -79,7 +79,7 @@ export interface RunServicePort {
   makeRunId(): string;
   listAllRuns(): Promise<RunListItem[]>;
   getRunIndex(runId: string): Promise<Result<RunIndex, string>>;
-  getRunParamsIndex(runId: string): Promise<Result<RunParams, string>>;
+  // getRunParamsIndex(runId: string): Promise<Result<RunParams, string>>;
 }
 
 export interface WsServicePort {

--- a/packages/runtime/src/create-services.ts
+++ b/packages/runtime/src/create-services.ts
@@ -14,19 +14,32 @@ import { FsFlowIndexStore } from "@lcase/adapters/flow-index-store";
 import { ServicesPort } from "@lcase/ports";
 import path from "node:path";
 import { FsForkSpecIndexStore } from "@lcase/adapters/fork-spec-index-store";
-import { FsRunParamsIndexStore } from "@lcase/adapters/run-params-index-store";
+// import { FsRunParamsIndexStore } from "@lcase/adapters/run-params-index-store";
+import { FsJsonIndexStore } from "../../adapters/dist/index-store/fs-json-index-store.js";
+import { FlowIndex, ForkSpec, ForkSpecIndex, RunIndex } from "@lcase/types";
 
 export function createServices(config: RuntimeConfig): ServicesPort {
   const ctx = makeRuntimeContext(config);
-  const flowIndexStore = new FsFlowIndexStore(
+  const flowIndexStoreOld = new FsFlowIndexStore(
     path.join(process.cwd(), "lcase-db/flows/index"),
   );
-  const forkSpecIndexStore = new FsForkSpecIndexStore(
-    path.join(process.cwd(), "lcase-db/sims/index"),
-  );
-  const runParamsIndexStore = new FsRunParamsIndexStore(
-    path.join(process.cwd(), "lcase-db/params/index"),
-  );
+  // const forkSpecIndexStore = new FsForkSpecIndexStore(
+  //   path.join(process.cwd(), "lcase-db/sims/index"),
+  // );
+  // const runParamsIndexStore = new FsRunParamsIndexStore(
+  //   path.join(process.cwd(), "lcase-db/params/index"),
+  // );
+
+  const flowIndexStore = new FsJsonIndexStore<FlowIndex>({
+    dir: path.join(process.cwd(), "lcase-db/flows/index"),
+    extension: ".index.json",
+  });
+
+  const forkSpecIndexStore = new FsJsonIndexStore<ForkSpecIndex>({
+    dir: path.join(process.cwd(), "lcase-db/sims/index"),
+    extension: ".index.json",
+  });
+
   const flow = new FlowService(
     ctx.bus,
     ctx.ef,
@@ -43,13 +56,13 @@ export function createServices(config: RuntimeConfig): ServicesPort {
     forkSpecIndexStore,
   );
   forkSpecIndexStore.init();
-  runParamsIndexStore.init();
+  // runParamsIndexStore.init();
   const ws = new WsService(ctx.bus);
   const run = new RunService({
     ef: ctx.ef,
     runStore: ctx.runIndexStore,
     flowStore: flowIndexStore,
-    runParamsStore: runParamsIndexStore,
+    // runParamsStore: runParamsIndexStore,
   });
 
   const artifact = new ArtifactService(ctx.artifacts);

--- a/packages/runtime/src/create-services.ts
+++ b/packages/runtime/src/create-services.ts
@@ -14,6 +14,7 @@ import { FsFlowIndexStore } from "@lcase/adapters/flow-index-store";
 import { ServicesPort } from "@lcase/ports";
 import path from "node:path";
 import { FsForkSpecIndexStore } from "@lcase/adapters/fork-spec-index-store";
+import { FsRunParamsIndexStore } from "@lcase/adapters/run-params-index-store";
 
 export function createServices(config: RuntimeConfig): ServicesPort {
   const ctx = makeRuntimeContext(config);
@@ -22,6 +23,9 @@ export function createServices(config: RuntimeConfig): ServicesPort {
   );
   const forkSpecIndexStore = new FsForkSpecIndexStore(
     path.join(process.cwd(), "lcase-db/sims/index"),
+  );
+  const runParamsIndexStore = new FsRunParamsIndexStore(
+    path.join(process.cwd(), "lcase-db/params/index"),
   );
   const flow = new FlowService(
     ctx.bus,
@@ -39,8 +43,14 @@ export function createServices(config: RuntimeConfig): ServicesPort {
     forkSpecIndexStore,
   );
   forkSpecIndexStore.init();
+  runParamsIndexStore.init();
   const ws = new WsService(ctx.bus);
-  const run = new RunService(ctx.ef, ctx.runIndexStore, flowIndexStore);
+  const run = new RunService({
+    ef: ctx.ef,
+    runStore: ctx.runIndexStore,
+    flowStore: flowIndexStore,
+    runParamsStore: runParamsIndexStore,
+  });
 
   const artifact = new ArtifactService(ctx.artifacts);
 

--- a/packages/runtime/src/registries/artifacts.registry.ts
+++ b/packages/runtime/src/registries/artifacts.registry.ts
@@ -1,11 +1,16 @@
 import { FsArtifactStore } from "@lcase/adapters/artifact-store";
 import type { Registry } from "../types/registry.js";
 import { Artifacts } from "@lcase/artifacts";
+import { FsArtifactIndexStore } from "@lcase/adapters/artifact-index-store";
 
 export const artifactRegistry = {
   embedded: {
     local: {
-      fs: (path: string) => new Artifacts(new FsArtifactStore(path)),
+      fs: (path: string) =>
+        new Artifacts(
+          new FsArtifactStore(path),
+          new FsArtifactIndexStore(path),
+        ),
     },
   },
 } as const satisfies Registry;

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -7,12 +7,11 @@ import { FlowStore, FlowStoreFs } from "@lcase/adapters/flow-store";
 import { Engine } from "@lcase/engine";
 
 import { EmitterFactory, eventSchemaRegistry } from "@lcase/events";
-import {
+import type {
   ArtifactsPort,
   EventBusPort,
   IndexStorePort,
   JobParserPort,
-  RunIndexStorePort,
   StreamRegistryPort,
 } from "@lcase/ports";
 import {
@@ -48,8 +47,6 @@ import { createLimiter } from "./wire-functions/create-limiter.js";
 import { ConcurrencyLimiter } from "@lcase/limiter";
 import { createArtifacts } from "./wire-functions/create-artifacts.js";
 import { FsRunIndexStore } from "@lcase/adapters/run-index-store";
-import { FsFlowIndexStore } from "@lcase/adapters/flow-index-store";
-import { FsForkSpecIndexStore } from "@lcase/adapters/fork-spec-index-store";
 import { FsJsonIndexStore } from "../../adapters/dist/index-store/fs-json-index-store.js";
 import { FlowIndex, ForkSpecIndex, RunIndex } from "@lcase/types";
 

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -10,6 +10,7 @@ import { EmitterFactory, eventSchemaRegistry } from "@lcase/events";
 import {
   ArtifactsPort,
   EventBusPort,
+  IndexStorePort,
   JobParserPort,
   RunIndexStorePort,
   StreamRegistryPort,
@@ -49,6 +50,8 @@ import { createArtifacts } from "./wire-functions/create-artifacts.js";
 import { FsRunIndexStore } from "@lcase/adapters/run-index-store";
 import { FsFlowIndexStore } from "@lcase/adapters/flow-index-store";
 import { FsForkSpecIndexStore } from "@lcase/adapters/fork-spec-index-store";
+import { FsJsonIndexStore } from "../../adapters/dist/index-store/fs-json-index-store.js";
+import { FlowIndex, ForkSpecIndex, RunIndex } from "@lcase/types";
 
 export function createRuntime(config: RuntimeConfig): WorkflowRuntime {
   const ctx = makeRuntimeContext(config);
@@ -60,12 +63,15 @@ export function createRuntime(config: RuntimeConfig): WorkflowRuntime {
     ctx.ef,
     new FlowStoreFs(),
     ctx.artifacts,
-    new FsFlowIndexStore(path.join(process.cwd(), "lcase-db/flows/index")),
+    new FsJsonIndexStore<FlowIndex>({
+      dir: path.join(process.cwd(), "lcase-db/flows/index"),
+    }),
   );
 
-  const forkSpecIndexStore = new FsForkSpecIndexStore(
-    path.join(process.cwd(), "lcase-db/sims/index"),
-  );
+  const forkSpecIndexStore = new FsJsonIndexStore<ForkSpecIndex>({
+    dir: path.join(process.cwd(), "lcase-db/sims/index"),
+    extension: ".index.json",
+  });
   const replayService = new ReplayService(ctx.replay);
   const simService = new SimService(
     ctx.artifacts,
@@ -118,9 +124,14 @@ export function makeRuntimeContext(config: RuntimeConfig): RuntimeContext {
 
   const jobParser = new JobParser(eventSchemaRegistry);
 
-  const runIndexStore = new FsRunIndexStore(
+  const runIndexStoreOld = new FsRunIndexStore(
     path.resolve(process.cwd(), "lcase-db/runs/index"),
   );
+
+  const runIndexStore = new FsJsonIndexStore<RunIndex>({
+    dir: path.resolve(process.cwd(), "lcase-db/runs/index"),
+    extension: ".index.json",
+  });
 
   const artifacts = createArtifacts(config.artifacts);
   const engine = createInProcessEngine(
@@ -228,7 +239,7 @@ export function createInProcessEngine(
   bus: EventBusPort,
   ef: EmitterFactory,
   jobParser: JobParserPort,
-  runIndexStore: RunIndexStorePort,
+  runIndexStore: IndexStorePort<RunIndex>,
   artifacts: ArtifactsPort,
 ): Engine {
   const engine = new Engine({

--- a/packages/runtime/src/types/runtime.context.ts
+++ b/packages/runtime/src/types/runtime.context.ts
@@ -4,7 +4,7 @@ import type {
   QueuePort,
   LimiterPort,
   ArtifactsPort,
-  RunIndexStorePort,
+  IndexStorePort,
 } from "@lcase/ports";
 import { Worker } from "@lcase/worker";
 import { FlowStore } from "@lcase/adapters/flow-store";
@@ -17,6 +17,7 @@ import {
 } from "@lcase/observability";
 import { EmitterFactory } from "@lcase/events";
 import { ReplayEngine } from "@lcase/replay";
+import { RunIndex } from "@lcase/types";
 
 export type SinkMap = {
   "console-log-sink"?: ConsoleSink;
@@ -37,5 +38,5 @@ export type RuntimeContext = {
   replay: ReplayEngine;
   limiter: LimiterPort;
   artifacts: ArtifactsPort;
-  runIndexStore: RunIndexStorePort;
+  runIndexStore: IndexStorePort<RunIndex>;
 };

--- a/packages/runtime/src/wire-functions/create-artifacts.ts
+++ b/packages/runtime/src/wire-functions/create-artifacts.ts
@@ -10,6 +10,6 @@ export function createArtifacts(config: ArtifactsConfig): ArtifactsPort {
   );
   console.log(config.path);
 
-  const limiter = makeArtifacts(config.path);
-  return limiter;
+  const artifacts = makeArtifacts(config.path);
+  return artifacts;
 }

--- a/packages/services/src/flow.service.ts
+++ b/packages/services/src/flow.service.ts
@@ -5,6 +5,7 @@ import type {
   FlowServicePort,
   ArtifactsPort,
   FlowIndexStorePort,
+  IndexStorePort,
 } from "@lcase/ports";
 import type { FlowDefinition, FlowIndex, Result } from "@lcase/types";
 import { EmitterFactory } from "@lcase/events";
@@ -21,7 +22,7 @@ export class FlowService implements FlowServicePort {
     private readonly ef: EmitterFactory,
     private readonly flowStore: FlowStorePort,
     private readonly artifacts: ArtifactsPort,
-    private readonly flowIndexStore: FlowIndexStorePort,
+    private readonly flowIndexStore: IndexStorePort<FlowIndex>,
   ) {}
 
   async startFlow(args: { absoluteFilePath?: string }): Promise<void> {
@@ -95,7 +96,10 @@ export class FlowService implements FlowServicePort {
   }
 
   async getAllFlowIndexes(): Promise<Result<FlowIndex[], string>> {
-    return await this.flowIndexStore.getAllFlowIndexes();
+    const indexes = await this.flowIndexStore.getAll();
+    if (indexes.length === 0)
+      return { ok: false, error: "No flow indexes found" };
+    return { ok: true, value: indexes };
   }
 
   validateJsonFlow(

--- a/packages/services/src/run.service.ts
+++ b/packages/services/src/run.service.ts
@@ -1,33 +1,31 @@
 import {
   EmitterFactoryPort,
-  FlowIndexStorePort,
-  RunIndexStorePort,
-  RunParamsIndexStorePort,
+  IndexStorePort,
   RunRequest,
   RunServicePort,
 } from "@lcase/ports";
 import { createRunId, runFlow } from "@lcase/run-flow";
 import { listAllRuns } from "@lcase/run-history";
-import { Result, RunIndex, RunParams } from "@lcase/types";
+import { FlowIndex, Result, RunIndex } from "@lcase/types";
 
 type RunServiceDeps = {
   ef: EmitterFactoryPort;
-  runStore: RunIndexStorePort;
-  flowStore: FlowIndexStorePort;
-  runParamsStore: RunParamsIndexStorePort;
+  runStore: IndexStorePort<RunIndex>;
+  flowStore: IndexStorePort<FlowIndex>;
+  // runParamsStore: RunParamsIndexStorePort;
 };
 
 export class RunService implements RunServicePort {
   private readonly ef: EmitterFactoryPort;
-  private readonly runStore: RunIndexStorePort;
-  private readonly flowStore: FlowIndexStorePort;
-  private readonly runParamsStore: RunParamsIndexStorePort;
+  private readonly runStore: IndexStorePort<RunIndex>;
+  private readonly flowStore: IndexStorePort<FlowIndex>;
+  // private readonly runParamsStore: RunParamsIndexStorePort;
 
   constructor(deps: RunServiceDeps) {
     this.ef = deps.ef;
     this.runStore = deps.runStore;
     this.flowStore = deps.flowStore;
-    this.runParamsStore = deps.runParamsStore;
+    // this.runParamsStore = deps.runParamsStore;
   }
 
   async requestRun(request: RunRequest) {
@@ -44,14 +42,14 @@ export class RunService implements RunServicePort {
   }
 
   async getRunIndex(runId: string): Promise<Result<RunIndex, string>> {
-    const runIndex = await this.runStore.getRunIndex(runId);
+    const runIndex = await this.runStore.get(runId);
     if (!runIndex) return { ok: false, error: "No run index found" };
     return { ok: true, value: runIndex };
   }
 
-  async getRunParamsIndex(runId: string): Promise<Result<RunParams, string>> {
-    const runParams = await this.runParamsStore.getRunParams(runId);
-    if (!runParams) return { ok: false, error: "Error getting run params" };
-    return { ok: true, value: runParams };
-  }
+  // async getRunParamsIndex(runId: string): Promise<Result<RunParams, string>> {
+  //   const runParams = await this.runParamsStore.getRunParams(runId);
+  //   if (!runParams) return { ok: false, error: "Error getting run params" };
+  //   return { ok: true, value: runParams };
+  // }
 }

--- a/packages/services/src/run.service.ts
+++ b/packages/services/src/run.service.ts
@@ -2,19 +2,33 @@ import {
   EmitterFactoryPort,
   FlowIndexStorePort,
   RunIndexStorePort,
+  RunParamsIndexStorePort,
   RunRequest,
   RunServicePort,
 } from "@lcase/ports";
 import { createRunId, runFlow } from "@lcase/run-flow";
 import { listAllRuns } from "@lcase/run-history";
-import { Result, RunIndex } from "@lcase/types";
+import { Result, RunIndex, RunParams } from "@lcase/types";
+
+type RunServiceDeps = {
+  ef: EmitterFactoryPort;
+  runStore: RunIndexStorePort;
+  flowStore: FlowIndexStorePort;
+  runParamsStore: RunParamsIndexStorePort;
+};
 
 export class RunService implements RunServicePort {
-  constructor(
-    private readonly ef: EmitterFactoryPort,
-    private readonly runStore: RunIndexStorePort,
-    private readonly flowStore: FlowIndexStorePort,
-  ) {}
+  private readonly ef: EmitterFactoryPort;
+  private readonly runStore: RunIndexStorePort;
+  private readonly flowStore: FlowIndexStorePort;
+  private readonly runParamsStore: RunParamsIndexStorePort;
+
+  constructor(deps: RunServiceDeps) {
+    this.ef = deps.ef;
+    this.runStore = deps.runStore;
+    this.flowStore = deps.flowStore;
+    this.runParamsStore = deps.runParamsStore;
+  }
 
   async requestRun(request: RunRequest) {
     await runFlow({ ...request, ef: this.ef });
@@ -33,5 +47,11 @@ export class RunService implements RunServicePort {
     const runIndex = await this.runStore.getRunIndex(runId);
     if (!runIndex) return { ok: false, error: "No run index found" };
     return { ok: true, value: runIndex };
+  }
+
+  async getRunParamsIndex(runId: string): Promise<Result<RunParams, string>> {
+    const runParams = await this.runParamsStore.getRunParams(runId);
+    if (!runParams) return { ok: false, error: "Error getting run params" };
+    return { ok: true, value: runParams };
   }
 }

--- a/packages/services/src/sim.service.ts
+++ b/packages/services/src/sim.service.ts
@@ -1,23 +1,22 @@
-import {
+import type {
   ArtifactsPort,
   EmitterFactoryPort,
   ForkSpecDetails,
-  ForkSpecIndexStorePort,
+  IndexStorePort,
   JsonValue,
-  RunIndexStorePort,
   SimServicePort,
 } from "@lcase/ports";
+import type { ForkSpecIndex, Result, RunIndex } from "@lcase/types";
 
 import { getRunFlowHash } from "@lcase/run-history";
 import { startForkedSim } from "@lcase/run-flow";
-import { ForkSpec, ForkSpecIndex, Result } from "@lcase/types";
 
 export class SimService implements SimServicePort {
   constructor(
     private readonly artifacts: ArtifactsPort,
     private readonly ef: EmitterFactoryPort,
-    private readonly runIndexStore: RunIndexStorePort,
-    private readonly forkSpecIndexStore: ForkSpecIndexStorePort,
+    private readonly runIndexStore: IndexStorePort<RunIndex>,
+    private readonly forkSpecIndexStore: IndexStorePort<ForkSpecIndex>,
   ) {}
 
   async startForkedRunSim(
@@ -59,7 +58,10 @@ export class SimService implements SimServicePort {
       forkSpecHash: result.value,
       ...(details.description ? { description: details.description } : {}),
     };
-    const indexResult = await this.forkSpecIndexStore.put(forkSpecIndex);
+    const indexResult = await this.forkSpecIndexStore.put(
+      result.value,
+      forkSpecIndex,
+    );
     if (!indexResult.ok) return { ok: false, error: indexResult.error };
     return { ok: true, value: result.value };
   }

--- a/packages/types/src/artifacts/artifact-index.ts
+++ b/packages/types/src/artifacts/artifact-index.ts
@@ -1,0 +1,10 @@
+export type ArtifactIndex = {
+  time: string; // iso datetime
+  hash: string; // hash of artifact
+  label?: string;
+  id?: string; // id for indexing later in sql
+  filename?: string; // original filename
+  contentType?: string;
+  size?: number;
+  format?: "json" | "text" | "markdown" | "bytes";
+};

--- a/packages/types/src/engine/run-index.ts
+++ b/packages/types/src/engine/run-index.ts
@@ -7,6 +7,7 @@ export type RunIndex = {
   startTime?: string;
   endTime?: string;
   duration?: number;
+  runInputHash?: string;
 
   steps: Record<
     string,

--- a/packages/types/src/engine/run-params.ts
+++ b/packages/types/src/engine/run-params.ts
@@ -1,0 +1,5 @@
+import type { JsonValue } from "../json-value.js";
+
+type Param = string;
+type Hash = string;
+export type RunParams = Record<Param, Hash>;

--- a/packages/types/src/engine/run-spec.ts
+++ b/packages/types/src/engine/run-spec.ts
@@ -1,0 +1,5 @@
+export type RunSpec = {
+  flowDefHash: string;
+  simSpecHash?: string;
+  runParamsHash?: string;
+};

--- a/packages/types/src/fs-json-index-store/fs-json-index-store.ts
+++ b/packages/types/src/fs-json-index-store/fs-json-index-store.ts
@@ -1,0 +1,21 @@
+// same type supplied by node fs promises I believe
+type BufferEncoding =
+  | "ascii"
+  | "utf8"
+  | "utf-8"
+  | "utf16le"
+  | "utf-16le"
+  | "ucs2"
+  | "ucs-2"
+  | "base64"
+  | "base64url"
+  | "latin1"
+  | "binary"
+  | "hex";
+
+export type FsJsonIndexStoreOptions<T> = {
+  dir: string;
+  extension?: string;
+  encoding?: BufferEncoding;
+  sort?: (a: T, b: T) => number;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -38,11 +38,13 @@ export * from "./tool/tool.types.js";
 
 export * from "./worker/metadata.js";
 export * from "./flow-analysis/types.js";
+
 export * from "./engine/fork-spec.type.js";
 export * from "./engine/run-context.js";
 export * from "./engine/run-index.js";
 export * from "./engine/run-plan.type.js";
 export * from "./engine/fork-spec-index.js";
+export * from "./engine/run-params.js";
 
 export * from "./flow-index-store/flow-index.js";
 
@@ -50,3 +52,6 @@ export * from "./flow-index-store/flow-index.js";
 export * from "./api/index.js";
 
 export * from "./run-index-store/run-list.js";
+
+// artifacts
+export * from "./artifacts/artifact-index.js";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -55,3 +55,6 @@ export * from "./run-index-store/run-list.js";
 
 // artifacts
 export * from "./artifacts/artifact-index.js";
+
+// generic file system json index store
+export * from "./fs-json-index-store/fs-json-index-store.js";

--- a/packages/use-cases/run-flow/src/add-flow.ts
+++ b/packages/use-cases/run-flow/src/add-flow.ts
@@ -1,11 +1,13 @@
 import type {
   ArtifactsPort,
   FlowIndexStorePort,
+  IndexStorePort,
   JsonValue,
 } from "@lcase/ports";
 import type { FlowDefinition, FlowIndex, Result } from "@lcase/types";
 import path from "node:path";
 import fs from "node:fs";
+import { createHash } from "node:crypto";
 
 export async function addFlowToCas(
   flowDef: FlowDefinition,
@@ -39,8 +41,15 @@ export function readFlowFile(absoluteFilePath: string): JsonValue {
 
 export async function addFlowIndex(
   index: FlowIndex,
-  store: FlowIndexStorePort,
+  store: IndexStorePort<FlowIndex>,
 ): Promise<Result<string, string>> {
-  const result = await store.putFlowIndex(index);
+  const id = makeId(index.name, index.version);
+  const result = await store.put(id, index);
   return result;
+}
+
+function makeId(name: string, version: string, path?: string, p0?: {}): string {
+  const hash = createHash("md5");
+  hash.update(name + version + path);
+  return hash.digest("hex");
 }

--- a/packages/use-cases/run-history/src/get-step-output-hashes.ts
+++ b/packages/use-cases/run-history/src/get-step-output-hashes.ts
@@ -1,4 +1,5 @@
-import type { RunIndexStorePort } from "@lcase/ports";
+import type { IndexStorePort } from "@lcase/ports";
+import type { RunIndex } from "@lcase/types";
 
 type RunId = string;
 type OutputHash = string;
@@ -13,9 +14,9 @@ type OutputHash = string;
 export async function getStepOutputHashes(
   stepIds: string[],
   runId: string,
-  store: RunIndexStorePort,
+  store: IndexStorePort<RunIndex>,
 ): Promise<Record<RunId, OutputHash> | undefined> {
-  const json = await store.getRunIndex(runId);
+  const json = await store.get(runId);
   if (!json) return;
 
   const hashMap: Record<RunId, OutputHash> = {};
@@ -30,9 +31,9 @@ export async function getStepOutputHashes(
 
 export async function getRunFlowHash(
   runId: string,
-  store: RunIndexStorePort,
+  store: IndexStorePort<RunIndex>,
 ): Promise<string | undefined> {
-  const json = await store.getRunIndex(runId);
+  const json = await store.get(runId);
 
   if (!json) return;
   return json.flowDefHash;

--- a/packages/use-cases/run-history/src/list-all-runs.ts
+++ b/packages/use-cases/run-history/src/list-all-runs.ts
@@ -1,24 +1,26 @@
-import { FlowIndexStorePort, RunIndexStorePort } from "@lcase/ports";
-import type { RunListItem } from "@lcase/types";
+import type { IndexStorePort } from "@lcase/ports";
+import type { FlowIndex, RunIndex, RunListItem } from "@lcase/types";
 
 export async function listAllRuns(
-  store: RunIndexStorePort,
-  flowStore: FlowIndexStorePort,
+  store: IndexStorePort<RunIndex>,
+  flowStore: IndexStorePort<FlowIndex>,
 ) {
   const runList: RunListItem[] = [];
 
-  const runIds = await store.getAllRunIds();
+  const runIds = await store.getIdList();
   for (const runId of runIds) {
-    const runIndex = await store.getRunIndex(runId);
+    const runIndex = await store.get(runId);
     if (!runIndex) continue;
     if (!runIndex.flowDefHash) continue;
 
-    const flowIndexResult = await flowStore.getFlowIndex(runIndex.flowDefHash);
-    if (!flowIndexResult.ok) continue;
+    // const flowIndexResult = await flowStore.getFlowIndex(runIndex.flowDefHash);
+    const flowIndexResult = await flowStore.get(runIndex.flowDefHash);
+
+    if (!flowIndexResult) continue;
     runList.push({
       runId,
-      flowName: flowIndexResult.value.name,
-      flowVersion: flowIndexResult.value.version,
+      flowName: flowIndexResult.name,
+      flowVersion: flowIndexResult.version,
       flowDefHash: runIndex.flowDefHash,
       forkSpecHash: runIndex.forkSpecHash,
       startTime: runIndex.startTime,

--- a/packages/use-cases/run-history/tests/get-step-output-hashes.test.ts
+++ b/packages/use-cases/run-history/tests/get-step-output-hashes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { getStepOutputHashes } from "../src/get-step-output-hashes.js";
-import type { RunIndexStorePort } from "@lcase/ports";
+import type { IndexStorePort, RunIndexStorePort } from "@lcase/ports";
 import type { RunIndex } from "@lcase/types";
 describe("run-history getStepOutputHashes()", () => {
   it("returns the correct step hashes from a list of steps", async () => {
@@ -20,8 +20,8 @@ describe("run-history getStepOutputHashes()", () => {
       },
     };
 
-    const getRunIndex = vi.fn().mockReturnValue(index);
-    const store = { getRunIndex } as unknown as RunIndexStorePort;
+    const get = vi.fn().mockReturnValue(index);
+    const store = { get } as unknown as IndexStorePort<RunIndex>;
 
     const result = await getStepOutputHashes(["a", "b"], "test-runid", store);
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -373,6 +373,7 @@ export class Worker implements WorkerPort {
   async bindValueRefs(refs: Ref[], data: Record<string, unknown>) {
     for (const ref of refs) {
       if (ref.hash === null) continue;
+
       const json = await this.getJsonArtifact(ref.hash);
       if (json === undefined) continue;
       const value = resolveJsonPath(ref.valuePath, json);


### PR DESCRIPTION
## Why

I’m preparing artifact and run-parameter storage so run payloads and outputs can be reliably written/read with format metadata.

This work supports:
- multi-format artifacts (`json`, `text`, `markdown`, `bytes`)
- sidecar metadata indexes for artifact lookup and type inference
- index infrastructure reused by related indexes

## Related Issues

- #219 
- #216
- #215
- #214

## What Changed

- Updated `Artifacts` to support multi-format put/get operations.
- Added automatic artifact sidecar metadata (`*.index.json`) containing fields such as format/content-type/size/time.
- Added a generic filesystem JSON index store.
- Built ArtifactIndex store for specific artifact related rules.
- Updated relevant wiring/call sites for artifact and indexes.

## Scope Notes

- This PR intentionally combines related storage/index groundwork in one pass.
- Package/layout refactors (domains/workflows/components naming) are deferred to follow-up work.

## Follow-ups (separate PRs)

1. Structure-only refactor (`use-cases` -> `workflows`, optional `domains/` grouping), no behavior change.
2. Runtime wiring cleanup and path centralization.
3. Further `Artifacts` internal split (thin facade + extracted domain functions).